### PR TITLE
Don't conditionally `CTFWeaponBase::WeaponRegenerate` for `impulse 101`

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -14785,11 +14785,7 @@ void CTFPlayer::CheatImpulseCommands( int iImpulse )
 						continue;
 
 					pWeapon->GiveDefaultAmmo();
-
-					if ( pWeapon->IsEnergyWeapon() || pWeapon->IsCaber())
-					{
-						pWeapon->WeaponRegenerate();
-					}
+					pWeapon->WeaponRegenerate();
 				}
 
 				m_Shared.m_flRageMeter = 100.f;

--- a/src/game/shared/tf/tf_weapon_bottle.h
+++ b/src/game/shared/tf/tf_weapon_bottle.h
@@ -91,7 +91,6 @@ public:
 
 	virtual void		Precache( void ) OVERRIDE;
 	virtual int			GetWeaponID( void ) const OVERRIDE { return TF_WEAPON_STICKBOMB; }
-	virtual bool		IsCaber( void ) const { return true; }
 	virtual void		Smack( void ) OVERRIDE;
 	virtual void		WeaponReset( void ) OVERRIDE;
 	virtual void		WeaponRegenerate( void ) OVERRIDE;

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -519,9 +519,6 @@ class CTFWeaponBase : public CBaseCombatWeapon, public IHasOwner, public IHasGen
 	virtual bool		IsBroken( void ) const { return false; }
 	virtual void		SetBroken( bool bBroken ) {}
 
-	// Caber
-	virtual bool		IsCaber( void ) const { return false; }
-
 // Server specific.
 #if !defined( CLIENT_DLL )
 


### PR DESCRIPTION
Weapon regeneration is implemented for `CTFWeaponBase`, so there isn't a good reason to restrict this based on the state of higher subclasses.

@allvei I believe this is a better way to achieve this rather than introducing `CTFWeaponBase::IsCaber`,  is this alright with you to merge?