### PR TITLE
Fix lock-on issues by making `tf_passtime_mode_lock_eye_to_eye` LOS only

### DIFF
--- a/src/game/shared/tf/passtime_convars.cpp
+++ b/src/game/shared/tf/passtime_convars.cpp
@@ -82,3 +82,4 @@ PASSTIME_CONVAR( p4ss_med_cansplash, 1, "Enables med splashing." );
 PASSTIME_CONVAR( p4ss_med_canpushball, 1, "Enables med pushing ball with crossbow." );
 
 PASSTIME_CONVAR( p4ss_golden_goal, 1, "Enables golden goal state when stalemate would happen." );
+PASSTIME_CONVAR( p4ss_lock_eye_to_eye_los, 1, "Check LOS eye-to-eye when trying to lock-on." );

--- a/src/game/shared/tf/passtime_convars.h
+++ b/src/game/shared/tf/passtime_convars.h
@@ -78,7 +78,8 @@ extern ConVar
 	p4ss_med_canpushball,
 	tf_passtime_pack_hp_per_sec,
 
-	p4ss_golden_goal;
+	p4ss_golden_goal,
+	p4ss_lock_eye_to_eye_los;
 
 enum class EPasstimeExperiment_Telepass { 
 	None,


### PR DESCRIPTION
Previously, we overrode the entire target position when eye-to-eye passing is enabled. This would cause issues when up-close to a player, as the target position you had to look at was now the player's eyes.

Resolve this by only using the eye-to-eye lock-on position for LOS checks -- the other positions are left as is upstream.

While we are here, move and rename our convar to `p4ss_lock_eye_to_eye_los`.