### PR TITLE
Adds input buffer for jack when equipped

### DIFF
--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -45,6 +45,7 @@ END_NETWORK_TABLE()
 BEGIN_PREDICTION_DATA( CPasstimeGun )
 #ifdef CLIENT_DLL
 	DEFINE_PRED_FIELD( m_eThrowState, FIELD_INTEGER, FTYPEDESC_INSENDTABLE ),
+	DEFINE_PRED_FIELD( m_fChargeBeginTime, FIELD_INTEGER, FTYPEDESC_INSENDTABLE ),
 #endif
 END_PREDICTION_DATA()
 
@@ -619,7 +620,7 @@ void CPasstimeGun::ItemPostFrame()
 			{
 			case THROWSTATE_IDLE:
 			{
-				if ( m_attack.Is( BUTTONSTATE_PRESSED ) )
+				if ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN ) )
 				{
 					// note: should transition to CHARGING even if it will immediately finish charging
 					m_eThrowState = THROWSTATE_CHARGING;


### PR DESCRIPTION
When equipping the jack, holding m1 before jack is fully deployed should now be buffered and predicted. 