### PR TITLE
New throw controls with buffer

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3756,6 +3756,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
 	RecvPropInt( RECVINFO( m_iPlayerSkinOverride ) ),
 	RecvPropBool( RECVINFO( m_bViewingCYOAPDA ) ),
 	RecvPropBool( RECVINFO( m_bRegenerating ) ),
+	RecvPropBool( RECVINFO( m_bLegacyPasstimeGunControls ) ),
 END_RECV_TABLE()
 
 

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3758,6 +3758,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
 	RecvPropBool( RECVINFO( m_bViewingCYOAPDA ) ),
 	RecvPropBool( RECVINFO( m_bRegenerating ) ),
 	RecvPropBool( RECVINFO( m_bLegacyPasstimeGunControls ) ),
+	RecvPropBool( RECVINFO( m_bReversedPasstimeGunControls ) ),
 	RecvPropBool( RECVINFO( m_bTyping ) ),
 END_RECV_TABLE()
 

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3757,6 +3757,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
 	RecvPropBool( RECVINFO( m_bViewingCYOAPDA ) ),
 	RecvPropBool( RECVINFO( m_bRegenerating ) ),
 	RecvPropBool( RECVINFO( m_bLegacyPasstimeGunControls ) ),
+	RecvPropBool( RECVINFO( m_bReversedPasstimeGunControls ) ),
 END_RECV_TABLE()
 
 

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3757,6 +3757,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
 	RecvPropInt( RECVINFO( m_iPlayerSkinOverride ) ),
 	RecvPropBool( RECVINFO( m_bViewingCYOAPDA ) ),
 	RecvPropBool( RECVINFO( m_bRegenerating ) ),
+	RecvPropBool( RECVINFO( m_bLegacyPasstimeGunControls ) ),
 	RecvPropBool( RECVINFO( m_bTyping ) ),
 END_RECV_TABLE()
 

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -296,6 +296,7 @@ public:
 	bool			ShouldAutoRezoom( void ){ return cl_autorezoom.GetBool(); }
 	bool			ShouldAutoReload( void ){ return cl_autoreload.GetBool(); }
 	bool			ShouldUseLegacyPasstimeGunControls( void ){ return m_bLegacyPasstimeGunControls; }
+	bool			ShouldUseReversedPasstimeGunControls( void ) { return  m_bReversedPasstimeGunControls; }
 
 	void			GetTargetIDDataString( bool bIsDisguised, OUT_Z_BYTECAP(iMaxLenInBytes) wchar_t *sDataString, int iMaxLenInBytes, bool &bIsAmmoData, bool &bIsKillStreakData );
 
@@ -957,6 +958,7 @@ private:
 	CNetworkVar( bool, m_bViewingCYOAPDA );
 	CNetworkVar( bool, m_bRegenerating );
 	CNetworkVar( bool, m_bLegacyPasstimeGunControls );
+	CNetworkVar( bool, m_bReversedPasstimeGunControls);
 	CNetworkVar( bool, m_bTyping );
 
 	bool m_bNotifiedWeaponInspectThisLife;

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -294,6 +294,7 @@ public:
 	bool			ShouldAutoRezoom( void ){ return cl_autorezoom.GetBool(); }
 	bool			ShouldAutoReload( void ){ return cl_autoreload.GetBool(); }
 	bool			ShouldUseLegacyPasstimeGunControls( void ){ return m_bLegacyPasstimeGunControls; }
+	bool			ShouldUseReversedPasstimeGunControls( void ) { return  m_bReversedPasstimeGunControls; }
 
 	void			GetTargetIDDataString( bool bIsDisguised, OUT_Z_BYTECAP(iMaxLenInBytes) wchar_t *sDataString, int iMaxLenInBytes, bool &bIsAmmoData, bool &bIsKillStreakData );
 
@@ -954,6 +955,7 @@ private:
 	CNetworkVar( bool, m_bViewingCYOAPDA );
 	CNetworkVar( bool, m_bRegenerating );
 	CNetworkVar( bool, m_bLegacyPasstimeGunControls );
+	CNetworkVar( bool, m_bReversedPasstimeGunControls);
 
 	bool m_bNotifiedWeaponInspectThisLife;
 

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -293,6 +293,7 @@ public:
 	bool			GetMedigunAutoHeal( void ){ return tf_medigun_autoheal.GetBool(); }
 	bool			ShouldAutoRezoom( void ){ return cl_autorezoom.GetBool(); }
 	bool			ShouldAutoReload( void ){ return cl_autoreload.GetBool(); }
+	bool			ShouldUseLegacyPasstimeGunControls( void ){ return m_bLegacyPasstimeGunControls; }
 
 	void			GetTargetIDDataString( bool bIsDisguised, OUT_Z_BYTECAP(iMaxLenInBytes) wchar_t *sDataString, int iMaxLenInBytes, bool &bIsAmmoData, bool &bIsKillStreakData );
 
@@ -952,6 +953,7 @@ private:
 	CNetworkVar( float, m_flHelpmeButtonPressTime );
 	CNetworkVar( bool, m_bViewingCYOAPDA );
 	CNetworkVar( bool, m_bRegenerating );
+	CNetworkVar( bool, m_bLegacyPasstimeGunControls );
 
 	bool m_bNotifiedWeaponInspectThisLife;
 

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -295,6 +295,7 @@ public:
 	bool			GetMedigunAutoHeal( void ){ return tf_medigun_autoheal.GetBool(); }
 	bool			ShouldAutoRezoom( void ){ return cl_autorezoom.GetBool(); }
 	bool			ShouldAutoReload( void ){ return cl_autoreload.GetBool(); }
+	bool			ShouldUseLegacyPasstimeGunControls( void ){ return m_bLegacyPasstimeGunControls; }
 
 	void			GetTargetIDDataString( bool bIsDisguised, OUT_Z_BYTECAP(iMaxLenInBytes) wchar_t *sDataString, int iMaxLenInBytes, bool &bIsAmmoData, bool &bIsKillStreakData );
 
@@ -955,6 +956,7 @@ private:
 	CNetworkVar( float, m_flHelpmeButtonPressTime );
 	CNetworkVar( bool, m_bViewingCYOAPDA );
 	CNetworkVar( bool, m_bRegenerating );
+	CNetworkVar( bool, m_bLegacyPasstimeGunControls );
 	CNetworkVar( bool, m_bTyping );
 
 	bool m_bNotifiedWeaponInspectThisLife;

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -844,6 +844,7 @@ IMPLEMENT_SERVERCLASS_ST( CTFPlayer, DT_TFPlayer )
 	SendPropBool( SENDINFO( m_bViewingCYOAPDA ) ),
 	SendPropBool( SENDINFO( m_bRegenerating ) ),
 	SendPropBool( SENDINFO( m_bLegacyPasstimeGunControls ) ),
+	SendPropBool( SENDINFO( m_bReversedPasstimeGunControls ) ),
 	SendPropBool( SENDINFO( m_bTyping ) ),
 END_SEND_TABLE()
 

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -843,6 +843,7 @@ IMPLEMENT_SERVERCLASS_ST( CTFPlayer, DT_TFPlayer )
 	SendPropInt( SENDINFO( m_iPlayerSkinOverride ) ),
 	SendPropBool( SENDINFO( m_bViewingCYOAPDA ) ),
 	SendPropBool( SENDINFO( m_bRegenerating ) ),
+	SendPropBool( SENDINFO( m_bLegacyPasstimeGunControls ) ),
 END_SEND_TABLE()
 
 // -------------------------------------------------------------------------------- //

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -843,6 +843,7 @@ IMPLEMENT_SERVERCLASS_ST( CTFPlayer, DT_TFPlayer )
 	SendPropInt( SENDINFO( m_iPlayerSkinOverride ) ),
 	SendPropBool( SENDINFO( m_bViewingCYOAPDA ) ),
 	SendPropBool( SENDINFO( m_bRegenerating ) ),
+	SendPropBool( SENDINFO( m_bLegacyPasstimeGunControls ) ),
 	SendPropBool( SENDINFO( m_bTyping ) ),
 END_SEND_TABLE()
 

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -844,6 +844,7 @@ IMPLEMENT_SERVERCLASS_ST( CTFPlayer, DT_TFPlayer )
 	SendPropBool( SENDINFO( m_bViewingCYOAPDA ) ),
 	SendPropBool( SENDINFO( m_bRegenerating ) ),
 	SendPropBool( SENDINFO( m_bLegacyPasstimeGunControls ) ),
+	SendPropBool( SENDINFO( m_bReversedPasstimeGunControls ) ),
 END_SEND_TABLE()
 
 // -------------------------------------------------------------------------------- //

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -458,6 +458,8 @@ public:
 	void SetAutoRezoom( bool bAutoRezoom ) { m_bAutoRezoom = bAutoRezoom; }
 	bool ShouldAutoReload( void ){ return m_bAutoReload; }
 	void SetAutoReload( bool bAutoReload ) { m_bAutoReload = bAutoReload; }
+	bool ShouldUseLegacyPasstimeGunControls( void ){ return m_bLegacyPasstimeGunControls; }
+	void SetUseLegacyPasstimeGunControls( bool value ) { m_bLegacyPasstimeGunControls = value; }
 
 	virtual void	ModifyOrAppendCriteria( AI_CriteriaSet& criteriaSet );
 
@@ -1227,6 +1229,7 @@ private:
 	bool 				m_bMedigunAutoHeal;
 	bool				m_bAutoRezoom;	// does the player want to re-zoom after each shot for sniper rifles
 	bool				m_bAutoReload;
+	CNetworkVar( bool, m_bLegacyPasstimeGunControls );
 
 	bool				m_bForceItemRemovalOnRespawn;
 

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -460,6 +460,8 @@ public:
 	void SetAutoReload( bool bAutoReload ) { m_bAutoReload = bAutoReload; }
 	bool ShouldUseLegacyPasstimeGunControls( void ){ return m_bLegacyPasstimeGunControls; }
 	void SetUseLegacyPasstimeGunControls( bool value ) { m_bLegacyPasstimeGunControls = value; }
+	bool ShouldUseReversedPasstimeGunControls( void ){ return m_bReversedPasstimeGunControls; }
+	void SetUseReversedPasstimeGunControls( bool value ) { m_bReversedPasstimeGunControls = value; }
 
 	virtual void	ModifyOrAppendCriteria( AI_CriteriaSet& criteriaSet );
 
@@ -1230,6 +1232,7 @@ private:
 	bool				m_bAutoRezoom;	// does the player want to re-zoom after each shot for sniper rifles
 	bool				m_bAutoReload;
 	CNetworkVar( bool, m_bLegacyPasstimeGunControls );
+	CNetworkVar( bool, m_bReversedPasstimeGunControls);
 
 	bool				m_bForceItemRemovalOnRespawn;
 

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -10246,6 +10246,7 @@ void CTFGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	pTFPlayer->m_bFlipViewModels = Q_strcmp( engine->GetClientConVarValue( pPlayer->entindex(), "cl_flipviewmodels" ), "1" ) == 0;
 
 	pTFPlayer->SetUseLegacyPasstimeGunControls( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "p4ss_legacy_throw_controls" ) ) > 0 );
+	pTFPlayer->SetUseReversedPasstimeGunControls( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "p4ss_reverse_throw_controls" ) ) > 0);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -10244,6 +10244,8 @@ void CTFGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	pTFPlayer->SetDefaultFOV( iFov );
 
 	pTFPlayer->m_bFlipViewModels = Q_strcmp( engine->GetClientConVarValue( pPlayer->entindex(), "cl_flipviewmodels" ), "1" ) == 0;
+
+	pTFPlayer->SetUseLegacyPasstimeGunControls( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "p4ss_legacy_throw_controls" ) ) > 0 );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -30,9 +30,8 @@
 static ConVar tf_passtime_mode_lock_eye_to_eye( "tf_passtime_mode_lock_eye_to_eye", "1" );
 #ifdef CLIENT_DLL
 static ConVar p4ss_legacy_throw_controls( "p4ss_legacy_throw_controls" , "0" , FCVAR_USERINFO, "For oldies who cannot fathom changes made to their game.");
+static ConVar p4ss_reverse_throw_controls( "p4ss_reverse_throw_controls", "0", FCVAR_USERINFO, "Switches mouse1 and mouse2 inputs for freethrow and passing" );
 #endif
-// FIXME: This isn't networked but should be similar to the above.
-static ConVar p4ss_reverse_throw_controls( "p4ss_reverse_throw_controls", "0", 0, "Switches mouse1 and mouse2 inputs for freethrow and passing" );
 
 //-----------------------------------------------------------------------------
 IMPLEMENT_NETWORKCLASS_ALIASED( PasstimeGun, DT_PasstimeGun )
@@ -401,7 +400,16 @@ void CPasstimeGun::ItemPostFrame()
 {
 	bool bCanAttack2Cancel = !tf_passtime_experiment_autopass.GetBool();
 
-	if (p4ss_reverse_throw_controls.GetBool() )
+	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
+	if ( !pOwner )
+	{
+		return;
+	}
+
+	bool bReversedCtrl = pOwner->ShouldUseReversedPasstimeGunControls();
+	bool bLegacyCtrl = pOwner->ShouldUseLegacyPasstimeGunControls();
+
+	if (bReversedCtrl)
 	{
 		m_attack.iButton = IN_ATTACK2;
 		m_attack2.iButton = IN_ATTACK;
@@ -411,14 +419,6 @@ void CPasstimeGun::ItemPostFrame()
 		m_attack.iButton = IN_ATTACK;
 		m_attack2.iButton = IN_ATTACK2;
 	}
-
-	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if ( !pOwner )
-	{
-		return;
-	}
-
-	bool bLegacyCtrl = pOwner->ShouldUseLegacyPasstimeGunControls();
 
 #ifdef GAME_DLL
 

--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -30,9 +30,8 @@
 static ConVar tf_passtime_mode_lock_eye_to_eye( "tf_passtime_mode_lock_eye_to_eye", "1" );
 #ifdef CLIENT_DLL
 static ConVar p4ss_legacy_throw_controls( "p4ss_legacy_throw_controls" , "0" , FCVAR_USERINFO, "For oldies who cannot fathom changes made to their game.");
+static ConVar p4ss_reverse_throw_controls( "p4ss_reverse_throw_controls", "0", FCVAR_USERINFO, "Switches mouse1 and mouse2 inputs for freethrow and passing" );
 #endif
-// FIXME: This isn't networked but should be similar to the above.
-static ConVar p4ss_reverse_throw_controls( "p4ss_reverse_throw_controls", "0", 0, "Switches mouse1 and mouse2 inputs for freethrow and passing" );
 
 //-----------------------------------------------------------------------------
 IMPLEMENT_NETWORKCLASS_ALIASED( PasstimeGun, DT_PasstimeGun )
@@ -402,7 +401,16 @@ void CPasstimeGun::ItemPostFrame()
 {
 	bool bCanAttack2Cancel = !tf_passtime_experiment_autopass.GetBool();
 
-	if (p4ss_reverse_throw_controls.GetBool() )
+	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
+	if ( !pOwner )
+	{
+		return;
+	}
+
+	bool bReversedCtrl = pOwner->ShouldUseReversedPasstimeGunControls();
+	bool bLegacyCtrl = pOwner->ShouldUseLegacyPasstimeGunControls();
+
+	if (bReversedCtrl)
 	{
 		m_attack.iButton = IN_ATTACK2;
 		m_attack2.iButton = IN_ATTACK;
@@ -412,14 +420,6 @@ void CPasstimeGun::ItemPostFrame()
 		m_attack.iButton = IN_ATTACK;
 		m_attack2.iButton = IN_ATTACK2;
 	}
-
-	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if ( !pOwner )
-	{
-		return;
-	}
-
-	bool bLegacyCtrl = pOwner->ShouldUseLegacyPasstimeGunControls();
 
 #ifdef GAME_DLL
 

--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -614,21 +614,16 @@ void CPasstimeGun::ItemPostFrame()
 		}
 		else 
 		{
-			//update input but not overwrite deploy buffer
-			if (!m_bDeploymentInputBuffer)
-			{
-				m_attack.Enable();
-				m_attack.Update(pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased);
-				m_attack2.Enable();
-				m_attack2.Update(pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased);
-			}
-			else
-			{
-				m_attack.Enable();
-				m_attack2.Enable();
-				m_bDeploymentInputBuffer = false;
-			}
-
+			// update input
+			m_attack.Enable();
+			m_attack.Update(pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased);
+			m_attack2.Enable();
+			m_attack2.Update(pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased);
+			
+			// get input buffer
+			bool bBufferM1 =  m_attack.Is( BUTTONSTATE_DOWN ) && m_bDeploymentInputBuffer;
+			bool bBufferM2 =  m_attack2.Is( BUTTONSTATE_DOWN ) && m_bDeploymentInputBuffer;
+			
 			if ( bCanAttack2Cancel && (
 				bLegacyCtrl
 				? m_attack2.Is( BUTTONSTATE_PRESSED )	// Legacy
@@ -655,11 +650,13 @@ void CPasstimeGun::ItemPostFrame()
 			case THROWSTATE_IDLE:
 			{
 				if ( bLegacyCtrl
-					? m_attack.Is(BUTTONSTATE_PRESSED) // Legacy
-					: ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack2.Is( BUTTONSTATE_PRESSED ) ) ) // New + input buffer
+					? (m_attack.Is(BUTTONSTATE_PRESSED) || bBufferM1 )
+					: ( m_attack.Is( BUTTONSTATE_PRESSED ) || bBufferM1 )
+						|| ( m_attack2.Is( BUTTONSTATE_PRESSED ) || bBufferM2 ) ) // New + input buffer
 				{
 					// note: should transition to CHARGING even if it will immediately finish charging
 					m_eThrowState = THROWSTATE_CHARGING;
+					m_bDeploymentInputBuffer = false; // reset buffer flag
 					m_fChargeBeginTime = gpGlobals->curtime;
 					if ( GetChargeMaxTime() != 0 )
 					{
@@ -925,21 +922,8 @@ bool CPasstimeGun::Deploy()
     m_attack2.UnlatchUp();
     m_attack.UnlatchUp();
 
-    // Update the input state only once
-    if (!m_bDeploymentInputBuffer)
-    {
-        m_attack.Update(GetTFPlayerOwner()->m_nButtons, GetTFPlayerOwner()->m_afButtonPressed, GetTFPlayerOwner()->m_afButtonReleased);
-        m_attack2.Update(GetTFPlayerOwner()->m_nButtons, GetTFPlayerOwner()->m_afButtonPressed, GetTFPlayerOwner()->m_afButtonReleased);
-		if (m_attack.Is(BUTTONSTATE_DOWN) )
-		{
-			m_attack.eButtonState = BUTTONSTATE_PRESSED;
-		}
-		if (m_attack2.Is(BUTTONSTATE_DOWN))
-		{
-			m_attack2.eButtonState = BUTTONSTATE_PRESSED;
-		}
-		m_bDeploymentInputBuffer = true;
-	}
+    // Update buffer flag
+	m_bDeploymentInputBuffer = true;
 	return true;
 }
 

--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -27,6 +27,13 @@
 #endif
 #include "tier0/memdbgon.h"
 
+static ConVar tf_passtime_mode_lock_eye_to_eye( "tf_passtime_mode_lock_eye_to_eye", "1" );
+#ifdef CLIENT_DLL
+static ConVar p4ss_legacy_throw_controls( "p4ss_legacy_throw_controls" , "0" , FCVAR_USERINFO, "For oldies who cannot fathom changes made to their game.");
+#endif
+// FIXME: This isn't networked but should be similar to the above.
+static ConVar p4ss_reverse_throw_controls( "p4ss_reverse_throw_controls", "0", 0, "Switches mouse1 and mouse2 inputs for freethrow and passing" );
+
 //-----------------------------------------------------------------------------
 IMPLEMENT_NETWORKCLASS_ALIASED( PasstimeGun, DT_PasstimeGun )
 
@@ -393,13 +400,26 @@ bool CPasstimeGun::SendWeaponAnim( int actBase )
 //-----------------------------------------------------------------------------
 void CPasstimeGun::ItemPostFrame()
 {
+	bool bCanAttack2Cancel = !tf_passtime_experiment_autopass.GetBool();
+
+	if (p4ss_reverse_throw_controls.GetBool() )
+	{
+		m_attack.iButton = IN_ATTACK2;
+		m_attack2.iButton = IN_ATTACK;
+	}
+	else
+	{
+		m_attack.iButton = IN_ATTACK;
+		m_attack2.iButton = IN_ATTACK2;
+	}
+
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
 	if ( !pOwner )
 	{
 		return;
 	}
 
-	bool bCanAttack2Cancel = !tf_passtime_experiment_autopass.GetBool();
+	bool bLegacyCtrl = pOwner->ShouldUseLegacyPasstimeGunControls();
 
 #ifdef GAME_DLL
 
@@ -598,7 +618,10 @@ void CPasstimeGun::ItemPostFrame()
 			m_attack2.Enable();
 			m_attack2.Update( pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased );
 
-			if ( bCanAttack2Cancel && m_attack2.Is( BUTTONSTATE_PRESSED ) )
+			if ( bCanAttack2Cancel && (
+				bLegacyCtrl
+				? m_attack2.Is( BUTTONSTATE_PRESSED )	// Legacy
+				: ( m_attack2.Is( BUTTONSTATE_PRESSED ) || m_attack.Is( BUTTONSTATE_PRESSED ) ) ) ) // New
 			{
 				// check for cancelling attack by pressing attack2
 				if ( (m_eThrowState == THROWSTATE_CHARGING) || (m_eThrowState == THROWSTATE_CHARGED) )
@@ -620,7 +643,9 @@ void CPasstimeGun::ItemPostFrame()
 			{
 			case THROWSTATE_IDLE:
 			{
-				if ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN ) )
+				if ( bLegacyCtrl
+					? m_attack.Is(BUTTONSTATE_PRESSED) ||  m_attack.Is(BUTTONSTATE_DOWN) // Legacy
+					: ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN) || m_attack2.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN) ) ) // New + input buffer
 				{
 					// note: should transition to CHARGING even if it will immediately finish charging
 					m_eThrowState = THROWSTATE_CHARGING;
@@ -642,7 +667,9 @@ void CPasstimeGun::ItemPostFrame()
 
 			case THROWSTATE_CHARGING: 
 			{
-				if ( m_attack.Is( BUTTONSTATE_RELEASED ) )
+				if ( bLegacyCtrl
+					? m_attack.Is(BUTTONSTATE_RELEASED)
+					: ( m_attack.Is( BUTTONSTATE_RELEASED ) || m_attack2.Is( BUTTONSTATE_RELEASED ) ) )
 				{
 					// NOTE: change state after calling Throw
 					Throw( pOwner );
@@ -665,7 +692,9 @@ void CPasstimeGun::ItemPostFrame()
 
 			case THROWSTATE_CHARGED:
 			{
-				if ( m_attack.Is( BUTTONSTATE_RELEASED ) )
+				if ( bLegacyCtrl
+					? m_attack.Is(BUTTONSTATE_RELEASED)
+					: ( m_attack.Is( BUTTONSTATE_RELEASED ) || m_attack2.Is( BUTTONSTATE_RELEASED ) ) )
 				{
 					// NOTE: change state after calling Throw
 					Throw( pOwner );

--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -645,7 +645,7 @@ void CPasstimeGun::ItemPostFrame()
 			{
 				if ( bLegacyCtrl
 					? m_attack.Is(BUTTONSTATE_PRESSED) ||  m_attack.Is(BUTTONSTATE_DOWN) // Legacy
-					: ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN) || m_attack2.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN) ) ) // New + input buffer
+					: ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN) || m_attack2.Is( BUTTONSTATE_PRESSED ) || m_attack2.Is(BUTTONSTATE_DOWN) ) ) // New + input buffer
 				{
 					// note: should transition to CHARGING even if it will immediately finish charging
 					m_eThrowState = THROWSTATE_CHARGING;
@@ -763,7 +763,9 @@ void CPasstimeGun::ItemPostFrame()
 	SetWeaponVisible( pOwner->m_Shared.HasPasstimeBall() );
 
 #ifdef CLIENT_DLL
-	if ( m_attack.Is( BUTTONSTATE_DOWN ) )
+	if ( bLegacyCtrl 
+		? m_attack.Is( BUTTONSTATE_DOWN ) 
+		: m_attack.Is( BUTTONSTATE_DOWN ) || m_attack2.Is( BUTTONSTATE_DOWN ) )
 	{
 		pOwner->SetFiredWeapon( true ); // not sure what this does, exactly, but it seems important
 	}

--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -74,6 +74,7 @@ CPasstimeGun::CPasstimeGun()
 	: m_flTargetResetTime( 0 )
 	, m_attack( IN_ATTACK )
 	, m_attack2( IN_ATTACK2 )
+	, m_bDeploymentInputBuffer(false) // Initialize the flag
 {
 	m_eThrowState = THROWSTATE_DISABLED;
 #ifdef CLIENT_DLL
@@ -153,25 +154,26 @@ bool CPasstimeGun::Holster( CBaseCombatWeapon *pSwitchingTo )
 //-----------------------------------------------------------------------------
 void CPasstimeGun::WeaponReset()
 {
-	// this can happen when the weapon is holstered or not
-	BaseClass::WeaponReset();
+    // this can happen when the weapon is holstered or not
+    BaseClass::WeaponReset();
 
-	if ( (m_eThrowState != THROWSTATE_DISABLED) && (m_eThrowState != THROWSTATE_IDLE) )
-	{
-		m_eThrowState = THROWSTATE_CANCELLED;
-		m_attack2.LatchUp();
-		m_attack.LatchUp();
-	}
+    if ((m_eThrowState != THROWSTATE_DISABLED) && (m_eThrowState != THROWSTATE_IDLE))
+    {
+        m_eThrowState = THROWSTATE_CANCELLED;
+        m_attack2.LatchUp();
+        m_attack.LatchUp();
+    }
 
 #ifdef CLIENT_DLL
-	if ( m_pBounceReticle )
-		m_pBounceReticle->Hide();
+    if (m_pBounceReticle)
+        m_pBounceReticle->Hide();
 #endif
 
-	CTFPlayer* pOwner = GetTFPlayerOwner();
-	if ( pOwner )
-		pOwner->m_Shared.SetPasstimePassTarget( 0 );
+    CTFPlayer* pOwner = GetTFPlayerOwner();
+    if (pOwner)
+        pOwner->m_Shared.SetPasstimePassTarget(0);
 
+    m_bDeploymentInputBuffer = false; // Reset the flag
 }
 
 //-----------------------------------------------------------------------------
@@ -612,11 +614,20 @@ void CPasstimeGun::ItemPostFrame()
 		}
 		else 
 		{
-			// update input
-			m_attack.Enable();
-			m_attack.Update( pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased );
-			m_attack2.Enable();
-			m_attack2.Update( pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased );
+			//update input but not overwrite deploy buffer
+			if (!m_bDeploymentInputBuffer)
+			{
+				m_attack.Enable();
+				m_attack.Update(pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased);
+				m_attack2.Enable();
+				m_attack2.Update(pOwner->m_nButtons, pOwner->m_afButtonPressed, pOwner->m_afButtonReleased);
+			}
+			else
+			{
+				m_attack.Enable();
+				m_attack2.Enable();
+				m_bDeploymentInputBuffer = false;
+			}
 
 			if ( bCanAttack2Cancel && (
 				bLegacyCtrl
@@ -644,8 +655,8 @@ void CPasstimeGun::ItemPostFrame()
 			case THROWSTATE_IDLE:
 			{
 				if ( bLegacyCtrl
-					? m_attack.Is(BUTTONSTATE_PRESSED) ||  m_attack.Is(BUTTONSTATE_DOWN) // Legacy
-					: ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack.Is(BUTTONSTATE_DOWN) || m_attack2.Is( BUTTONSTATE_PRESSED ) || m_attack2.Is(BUTTONSTATE_DOWN) ) ) // New + input buffer
+					? m_attack.Is(BUTTONSTATE_PRESSED) // Legacy
+					: ( m_attack.Is( BUTTONSTATE_PRESSED ) || m_attack2.Is( BUTTONSTATE_PRESSED ) ) ) // New + input buffer
 				{
 					// note: should transition to CHARGING even if it will immediately finish charging
 					m_eThrowState = THROWSTATE_CHARGING;
@@ -904,15 +915,31 @@ const char *CPasstimeGun::GetWorldModel() const
 //-----------------------------------------------------------------------------
 bool CPasstimeGun::Deploy()
 {
-	// This is not called on the client because the client can't predict it.
-	if ( !BaseClass::Deploy() )
-	{
-		return false;
+    // This is not called on the client because the client can't predict it.
+    if (!BaseClass::Deploy())
+    {
+        return false;
+    }
+
+    m_eThrowState = THROWSTATE_IDLE;
+    m_attack2.UnlatchUp();
+    m_attack.UnlatchUp();
+
+    // Update the input state only once
+    if (!m_bDeploymentInputBuffer)
+    {
+        m_attack.Update(GetTFPlayerOwner()->m_nButtons, GetTFPlayerOwner()->m_afButtonPressed, GetTFPlayerOwner()->m_afButtonReleased);
+        m_attack2.Update(GetTFPlayerOwner()->m_nButtons, GetTFPlayerOwner()->m_afButtonPressed, GetTFPlayerOwner()->m_afButtonReleased);
+		if (m_attack.Is(BUTTONSTATE_DOWN) )
+		{
+			m_attack.eButtonState = BUTTONSTATE_PRESSED;
+		}
+		if (m_attack2.Is(BUTTONSTATE_DOWN))
+		{
+			m_attack2.eButtonState = BUTTONSTATE_PRESSED;
+		}
+		m_bDeploymentInputBuffer = true;
 	}
-	
-	m_eThrowState = THROWSTATE_IDLE;
-	m_attack2.UnlatchUp();
-	m_attack.UnlatchUp();
 	return true;
 }
 

--- a/src/game/shared/tf/tf_weapon_passtime_gun.cpp
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.cpp
@@ -28,7 +28,10 @@
 #include "tier0/memdbgon.h"
 
 static ConVar tf_passtime_mode_lock_eye_to_eye( "tf_passtime_mode_lock_eye_to_eye", "1" );
-static ConVar p4ss_legacy_throw_controls( "p4ss_legacy_throw_controls" , "0" , 0, "For oldies who cannot fathom changes made to their game.");
+#ifdef CLIENT_DLL
+static ConVar p4ss_legacy_throw_controls( "p4ss_legacy_throw_controls" , "0" , FCVAR_USERINFO, "For oldies who cannot fathom changes made to their game.");
+#endif
+// FIXME: This isn't networked but should be similar to the above.
 static ConVar p4ss_reverse_throw_controls( "p4ss_reverse_throw_controls", "0", 0, "Switches mouse1 and mouse2 inputs for freethrow and passing" );
 
 //-----------------------------------------------------------------------------
@@ -396,7 +399,6 @@ bool CPasstimeGun::SendWeaponAnim( int actBase )
 //-----------------------------------------------------------------------------
 void CPasstimeGun::ItemPostFrame()
 {
-	bool bLegacyCtrl = p4ss_legacy_throw_controls.GetBool();
 	bool bCanAttack2Cancel = !tf_passtime_experiment_autopass.GetBool();
 
 	if (p4ss_reverse_throw_controls.GetBool() )
@@ -416,6 +418,7 @@ void CPasstimeGun::ItemPostFrame()
 		return;
 	}
 
+	bool bLegacyCtrl = pOwner->ShouldUseLegacyPasstimeGunControls();
 
 #ifdef GAME_DLL
 

--- a/src/game/shared/tf/tf_weapon_passtime_gun.h
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.h
@@ -116,7 +116,7 @@ protected:
 			: iButton( button ), eButtonState( BUTTONSTATE_UP )
 			, bLatchedUp( false )
 		{}
-		const int iButton;
+		int iButton;
 		EButtonState eButtonState;
 		bool bLatchedUp;
 

--- a/src/game/shared/tf/tf_weapon_passtime_gun.h
+++ b/src/game/shared/tf/tf_weapon_passtime_gun.h
@@ -144,7 +144,7 @@ protected:
 #ifdef GAME_DLL
 	CPasstimeBallControllerHoming m_ballController;
 #endif
-
+	bool m_bDeploymentInputBuffer; // Passtimegun deployment buffer flag
 };
 
 #endif // TF_WEAPON_PASSTIME_GUN_H  


### PR DESCRIPTION
Adds new controls, with p4ss_legacy_throw_controls [0/1] and p4ss_reverse_throw_controls [0/1]. Game will default to the new and improved controls (Legacy controls turned off [0] ). This should also fix our new controls being client sided as well as adding input buffer for all kinds of throws. Issue #60 and #95. 