### PR TITLE
Keep last weapon used when using the resupply command - closes #105

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -7185,7 +7185,9 @@ void CTFPlayer::Resupply( void )
 	if ( TFGameRules()->State_Get() == GR_STATE_TEAM_WIN && TFGameRules()->GetWinningTeam() != GetTeamNumber() ) 
 		return;
 
+	iLastWeapon = m_iLastWeaponSlot;
 	ForceRegenerateAndRespawn();
+	m_iLastWeaponSlot = iLastWeapon;
 }
 
 void CC_Resupply( void )


### PR DESCRIPTION
Save m_iLastWeaponSlot to a temporary int iLastWeapon.
After ForceRegenerateAndRespawn() NULL's m_iLastWeaponSlot, retrieve the value from iLastWeapon. 