### PR TITLE
Cvar added to allow whistling in several new usable cases.

### DIFF
--- a/src/game/client/tf/tf_hud_passtime.cpp
+++ b/src/game/client/tf/tf_hud_passtime.cpp
@@ -377,9 +377,21 @@ void CTFHudPasstimePassNotify::OnTick()
 			m_pTextBox->SetVisible( false );
 		}
 
-		if ( m_pSpeechIndicator )
+		// If p4ss_whistle_more = 0, don't show the speech indicator of
+		// carrier or observer
+		if ( !p4ss_whistle_more.GetBool() 
+			|| pLocalPlayer->IsObserver() 
+			|| (pBallCarrier == pLocalPlayer) )
 		{
-			m_pSpeechIndicator->SetVisible( false );
+			if ( m_pSpeechIndicator )
+			{
+				m_pSpeechIndicator->SetVisible( false );
+				pLocalPlayer->m_Shared.SetAskForBallTime(0);
+			}
+		}
+		else
+		{
+			m_pSpeechIndicator->SetVisible( pLocalPlayer->m_Shared.AskForBallTime() > gpGlobals->curtime );
 		}
 
 		if ( m_pPassLockIndicator )
@@ -404,7 +416,7 @@ void CTFHudPasstimePassNotify::OnTick()
 		bTargetable = tr.fraction == 1;
 	}
 
-	if ( !bTargetable ) 
+	if ( !bTargetable ) // Not in range or not in LOS
 	{
 		if ( m_pTextBox )
 		{

--- a/src/game/server/tf/tf_passtime_logic.cpp
+++ b/src/game/server/tf/tf_passtime_logic.cpp
@@ -1074,6 +1074,23 @@ void CTFPasstimeLogic::StopAskForBallEffects()
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Stop ask for ball effects on players in opposing team of the ball carrier.
+//-----------------------------------------------------------------------------
+void CTFPasstimeLogic::StopAskForBallEffectsOnOpposingTeam(CTFPlayer *pCarrier)
+{
+	int carrierTeam = pCarrier->GetTeamNumber();
+
+    for (int i = 1; i <= MAX_PLAYERS; i++)
+    {
+        CTFPlayer *pPlayer = ToTFPlayer(UTIL_PlayerByIndex(i));
+        if ( pPlayer && ( pPlayer->GetTeamNumber() != carrierTeam || pPlayer == pCarrier ) )
+        {
+            pPlayer->m_Shared.SetAskForBallTime(0);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
 void CTFPasstimeLogic::OnBallCarrierMeleeHit( CTFPlayer *pPlayer, CTFPlayer *pAttacker ) 
 {
 	// TODO refactor OnBallCarrierMeleeHit and OnBallCarrierDamaged for less copypasta
@@ -1314,7 +1331,10 @@ void CTFPasstimeLogic::EjectBall( CTFPlayer *pPlayer, CTFPlayer *pAttacker )
 //-----------------------------------------------------------------------------
 void CTFPasstimeLogic::LaunchBall( CTFPlayer *pPlayer, const Vector &vecPos, const Vector &vecVel )
 {
-	StopAskForBallEffects();
+	if ( !p4ss_whistle_more.GetBool() )
+	{
+		StopAskForBallEffects();
+	}
 	m_hBall->SetStateFree();
 	m_hBall->MoveTo( vecPos, vecVel );
 	m_onBallFree.FireOutput( m_hBall, this );
@@ -1806,8 +1826,15 @@ void CTFPasstimeLogic::OnPlayerTouchBall( CTFPlayer *pCatcher, CPasstimeBall *pB
 
 //-----------------------------------------------------------------------------
 void CTFPasstimeLogic::OnBallGet() 
-{
-	StopAskForBallEffects();
+{	
+	if ( p4ss_whistle_more.GetBool() )
+	{
+		StopAskForBallEffectsOnOpposingTeam(m_hBall->GetCarrier());
+	}
+	else
+	{
+		StopAskForBallEffects();
+	}
 	if ( CTFPlayer *pPlayer = m_hBall->GetCarrier() )
 	{
 		m_onBallGetAny.FireOutput( pPlayer, this );

--- a/src/game/server/tf/tf_passtime_logic.h
+++ b/src/game/server/tf/tf_passtime_logic.h
@@ -76,6 +76,7 @@ private:
 	void InputJumpPadUsed( inputdata_t &input );
 
 	void StopAskForBallEffects();
+	void StopAskForBallEffectsOnOpposingTeam(CTFPlayer *pCarrier);
 	void OnBallGet();
 	void Score( CTFPlayer *pPlayer, CFuncPasstimeGoal *pGoal );
 	void Score( CPasstimeBall *pBall, CFuncPasstimeGoal *pGoal, bool isDeathBomb );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -113,6 +113,7 @@
 #include "tf_player_resource.h"
 #include "gcsdk/gcclient_sharedobjectcache.h"
 #include "tf_party.h"
+#include "passtime_convars.h"
 
 #ifdef TF_RAID_MODE
 #include "bot_npc/bot_npc_decoy.h"
@@ -16087,7 +16088,7 @@ bool CTFPlayer::SayAskForBall()
 	}
 
 	CTFPlayer *pBallCarrier = pBall->GetCarrier();
-	if ( !pBallCarrier )
+	if ( !pBallCarrier && !p4ss_whistle_more.GetBool())
 	{
 		return false;
 	}

--- a/src/game/shared/tf/passtime_convars.cpp
+++ b/src/game/shared/tf/passtime_convars.cpp
@@ -83,3 +83,4 @@ PASSTIME_CONVAR( p4ss_med_canpushball, 1, "Enables med pushing ball with crossbo
 
 PASSTIME_CONVAR( p4ss_golden_goal, 1, "Enables golden goal state when stalemate would happen." );
 PASSTIME_CONVAR( p4ss_lock_eye_to_eye_los, 1, "Check LOS eye-to-eye when trying to lock-on." );
+PASSTIME_CONVAR( p4ss_whistle_more, 1, "Allows users to whistle in more use cases." );

--- a/src/game/shared/tf/passtime_convars.h
+++ b/src/game/shared/tf/passtime_convars.h
@@ -79,7 +79,8 @@ extern ConVar
 	tf_passtime_pack_hp_per_sec,
 
 	p4ss_golden_goal,
-	p4ss_lock_eye_to_eye_los;
+	p4ss_lock_eye_to_eye_los,
+	p4ss_whistle_more;
 
 enum class EPasstimeExperiment_Telepass { 
 	None,


### PR DESCRIPTION
Users can now whistle when ball is free and when being passed to someone else. The whistle icon also stays between ball exchanges within your team and the free state. #111

Cvar p4ss_whistle_more [0/1] defaults to 1.