### PR TITLE
Makes banned stock weapons unable to be equipped.

### DIFF
--- a/game/p4ss/scripts/items/items_game.txt
+++ b/game/p4ss/scripts/items/items_game.txt
@@ -20550,7 +20550,6 @@
 			{
 				"engineer"	"primary"
 				"pyro" "secondary"
-				"soldier" "secondary"
 				"heavy" "secondary"
 			}
 			"attributes"
@@ -20856,7 +20855,6 @@
 			"attach_to_hands"	"1"
 			"used_by_classes"
 			{
-				"demoman"	"1"
 			}
 			"static_attrs"
 			{
@@ -20899,7 +20897,6 @@
 			"attach_to_hands"	"1"
 			"used_by_classes"
 			{
-				"medic"	"1"
 			}
 			"static_attrs"
 			{


### PR DESCRIPTION
Soldier can no longer use stock shotgun in any form. 
Demo can no longer use stock stickies in any form. 
Medic can no longer use stock syringe gun in any form. 
Fixes issue #23