### PR TITLE
Fix player names being limited to 31 chars instead of 32

### DIFF
--- a/src/game/client/death.cpp
+++ b/src/game/client/death.cpp
@@ -231,8 +231,8 @@ void CHudDeathNotice::FireGameEvent( KeyValues * event)
 	if ( !victim_name )
 		victim_name = "";
 
-	Q_strncpy( rgDeathNoticeList[i].szKiller, killer_name, MAX_PLAYER_NAME_LENGTH );
-	Q_strncpy( rgDeathNoticeList[i].szVictim, victim_name, MAX_PLAYER_NAME_LENGTH );
+	Q_strncpy( rgDeathNoticeList[i].szKiller, killer_name, MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL );
+	Q_strncpy( rgDeathNoticeList[i].szVictim, victim_name, MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL );
 
 	if ( killer == victim || killer == 0 )
 		rgDeathNoticeList[i].iSuicide = true;

--- a/src/game/client/game_controls/ClientScoreBoardDialog.cpp
+++ b/src/game/client/game_controls/ClientScoreBoardDialog.cpp
@@ -331,7 +331,7 @@ void CClientScoreBoardDialog::UpdatePlayerInfo()
 			const char *oldName = playerData->GetString("name","");
 			char newName[MAX_PLAYER_NAME_LENGTH];
 
-			UTIL_MakeSafeName( oldName, newName, MAX_PLAYER_NAME_LENGTH );
+			UTIL_MakeSafeName( oldName, newName, MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL );
 
 			playerData->SetString("name", newName);
 

--- a/src/game/client/hl2mp/hud_deathnotice.cpp
+++ b/src/game/client/hl2mp/hud_deathnotice.cpp
@@ -313,8 +313,8 @@ void CHudDeathNotice::FireGameEvent( IGameEvent * event )
 	DeathNoticeItem deathMsg;
 	deathMsg.Killer.iEntIndex = killer;
 	deathMsg.Victim.iEntIndex = victim;
-	Q_strncpy( deathMsg.Killer.szName, killer_name, MAX_PLAYER_NAME_LENGTH );
-	Q_strncpy( deathMsg.Victim.szName, victim_name, MAX_PLAYER_NAME_LENGTH );
+	Q_strncpy( deathMsg.Killer.szName, killer_name, MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL );
+	Q_strncpy( deathMsg.Victim.szName, victim_name, MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL );
 	deathMsg.flDisplayTime = gpGlobals->curtime + hud_deathnotice_time.GetFloat();
 	deathMsg.iSuicide = ( !killer || killer == victim );
 

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -10217,7 +10217,7 @@ void CTFGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 
 	// msg everyone if someone changes their name,  and it isn't the first time (changing no name to current name)
 	// Note, not using FStrEq so that this is case sensitive
-	if ( pszOldName[0] != 0 && Q_strncmp( pszOldName, pszName, MAX_PLAYER_NAME_LENGTH-1 ) )		
+	if ( pszOldName[0] != 0 && Q_strncmp( pszOldName, pszName, MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL ) )		
 	{
 		ChangePlayerName( pTFPlayer, pszName );
 	}

--- a/src/game/shared/util_shared.cpp
+++ b/src/game/shared/util_shared.cpp
@@ -1243,7 +1243,7 @@ char *UTIL_GetFilteredPlayerName( const CSteamID &steamID, char *pszName )
 
 	if ( SteamUtils() )
 	{
-		SteamUtils()->FilterText( k_ETextFilteringContextName, steamID, pszName, pszName, MAX_PLAYER_NAME_LENGTH );
+		SteamUtils()->FilterText( k_ETextFilteringContextName, steamID, pszName, pszName, MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL );
 	}
 	return pszName;
 }

--- a/src/public/const.h
+++ b/src/public/const.h
@@ -36,9 +36,11 @@
 #define ABSOLUTE_PLAYER_LIMIT 255  // not 256, so we can send the limit as a byte 
 #define ABSOLUTE_PLAYER_LIMIT_DW	( (ABSOLUTE_PLAYER_LIMIT/32) + 1 )
 
-// a player name may have 31 chars + 0 on the PC.
-// the 360 only allows 15 char + 0, but stick with the larger PC size for cross-platform communication
-#define MAX_PLAYER_NAME_LENGTH		32
+// Steam allows 32 visible characters for account names
+// MAX_PLAYER_NAME_LENGTH is the buffer size including null terminator
+// MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL is the maximum number of characters without null terminator
+#define MAX_PLAYER_NAME_LENGTH		33  // 32 chars + null terminator
+#define MAX_PLAYER_NAME_LENGTH_WITHOUT_NULL	32  // matches Steam's limit
 
 #ifdef _X360
 #define MAX_PLAYERS_PER_CLIENT		XUSER_MAX_COUNT	// Xbox 360 supports 4 players per console


### PR DESCRIPTION
The MAX_PLAYER_NAME_LENGTH 32 didn't account for the null terminator, so all the names were restricted to 31 characters.

Untested at this moment.