### PR TITLE
Disabled contracker

### DIFF
--- a/src/game/client/in_steamcontroller.cpp
+++ b/src/game/client/in_steamcontroller.cpp
@@ -150,7 +150,7 @@ static ControllerDigitalActionToCommand g_ControllerDigitalGameActions[] =
 	{ "inspect", "+inspect", CONTROLLER_ACTION_FLAGS_NEEDS_DEBOUNCE },
 	{ "taunt", "+taunt", CONTROLLER_ACTION_FLAGS_NEEDS_DEBOUNCE },
 	{ "voicerecord", "+voicerecord", CONTROLLER_ACTION_FLAGS_NONE },
-	{ "show_quest_log", "show_quest_log", CONTROLLER_ACTION_FLAGS_NEEDS_DEBOUNCE },
+//	{ "show_quest_log", "show_quest_log", CONTROLLER_ACTION_FLAGS_NEEDS_DEBOUNCE },
 	{ "showscores", "+showscores", CONTROLLER_ACTION_FLAGS_NONE },
 	{ "callvote", "callvote", CONTROLLER_ACTION_FLAGS_NONE },
 	{ "cl_trigger_first_notification", "cl_trigger_first_notification", CONTROLLER_ACTION_FLAGS_NEEDS_DEBOUNCE },

--- a/src/game/client/tf/vgui/tf_quest_map_panel.cpp
+++ b/src/game/client/tf/vgui/tf_quest_map_panel.cpp
@@ -1227,6 +1227,8 @@ void CQuestMapPanel::GoToCurrentQuest()
 // Debugging functions
 //
 
+// Disabled to avoid an exploit in pass time
+/*
 CON_COMMAND( show_quest_log, "Show the quest map panel" )
 {
 	if ( GetQuestMapPanel()->IsVisible() )
@@ -1248,4 +1250,4 @@ CON_COMMAND( show_quest_log, "Show the quest map panel" )
 			GetQuestMapPanel()->GoToCurrentQuest();
 		}
 	}
-}
+}*/

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -8080,6 +8080,8 @@ bool CTFPlayer::ClientCommand( const CCommand &args )
 		
 		return true;
 	}
+
+//	Disabled to avoid an exploit in pass time
 /*	else if ( FStrEq( "cyoa_pda_open", pcmd ) )
 	{
 		bool bOpen = atoi( args[1] ) != 0;

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -8080,7 +8080,7 @@ bool CTFPlayer::ClientCommand( const CCommand &args )
 		
 		return true;
 	}
-	else if ( FStrEq( "cyoa_pda_open", pcmd ) )
+/*	else if ( FStrEq( "cyoa_pda_open", pcmd ) )
 	{
 		bool bOpen = atoi( args[1] ) != 0;
 
@@ -8094,7 +8094,7 @@ bool CTFPlayer::ClientCommand( const CCommand &args )
 			TeamFortress_SetSpeed();
 		}
 		return true;
-	}
+	}*/
 
 	return BaseClass::ClientCommand( args );
 }


### PR DESCRIPTION
Disables the contracker console commands for the client effectively patching the exploit.

There still possibly exists a custom HUD workaround to continue this, however, fixing that requires a larger effort I'd deem unnecessary as long as it isn't abused.