### PR TITLE
Increase server float precision for rounding m_flDucktime to resolve prediction errors.

### DIFF
--- a/src/game/server/playerlocaldata.cpp
+++ b/src/game/server/playerlocaldata.cpp
@@ -30,7 +30,7 @@ BEGIN_SEND_TABLE_NOBASE( CPlayerLocalData, DT_Local )
 	SendPropInt		(SENDINFO(m_bDucked),	1, SPROP_UNSIGNED ),
 	SendPropInt		(SENDINFO(m_bDucking),	1, SPROP_UNSIGNED ),
 	SendPropInt		(SENDINFO(m_bInDuckJump),	1, SPROP_UNSIGNED ),
-	SendPropFloat	(SENDINFO(m_flDucktime), 12, SPROP_ROUNDDOWN|SPROP_CHANGES_OFTEN, 0.0f, 2048.0f ),
+	SendPropFloat	(SENDINFO(m_flDucktime), 16, SPROP_ROUNDDOWN|SPROP_CHANGES_OFTEN, 0.0f, 2048.0f ), // Set 12 to 16 bits, resulting in more accurate rounding, eliminating prediction errors
 	SendPropFloat	(SENDINFO(m_flDuckJumpTime), 12, SPROP_ROUNDDOWN, 0.0f, 2048.0f ),
 	SendPropFloat	(SENDINFO(m_flJumpTime), 12, SPROP_ROUNDDOWN, 0.0f, 2048.0f ),
 #if PREDICTION_ERROR_CHECK_LEVEL > 1 

--- a/src/game/server/playerlocaldata.cpp
+++ b/src/game/server/playerlocaldata.cpp
@@ -30,7 +30,7 @@ BEGIN_SEND_TABLE_NOBASE( CPlayerLocalData, DT_Local )
 	SendPropInt		(SENDINFO(m_bDucked),	1, SPROP_UNSIGNED ),
 	SendPropInt		(SENDINFO(m_bDucking),	1, SPROP_UNSIGNED ),
 	SendPropInt		(SENDINFO(m_bInDuckJump),	1, SPROP_UNSIGNED ),
-	SendPropFloat	(SENDINFO(m_flDucktime), 16, SPROP_ROUNDDOWN|SPROP_CHANGES_OFTEN, 0.0f, 2048.0f ), // Set 12 to 16 bits, resulting in more accurate rounding, eliminating prediction errors
+	SendPropFloat	(SENDINFO(m_flDucktime), 32, SPROP_ROUNDDOWN|SPROP_CHANGES_OFTEN, 0.0f, 2048.0f ), // Set 12 to 16 bits, resulting in more accurate rounding, eliminating prediction errors
 	SendPropFloat	(SENDINFO(m_flDuckJumpTime), 12, SPROP_ROUNDDOWN, 0.0f, 2048.0f ),
 	SendPropFloat	(SENDINFO(m_flJumpTime), 12, SPROP_ROUNDDOWN, 0.0f, 2048.0f ),
 #if PREDICTION_ERROR_CHECK_LEVEL > 1 

--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -4399,10 +4399,8 @@ void CGameMovement::Duck( void )
 			// The player is in duck transition and not duck-jumping.
 			if ( player->m_Local.m_bDucking && !bDuckJump && !bDuckJumpTime )
 			{
-				// Convert duck time to ticks for consistent timing
-				int ticksRemaining = (int)((GAMEMOVEMENT_DUCK_TIME - player->m_Local.m_flDucktime) / (gpGlobals->interval_per_tick * 1000.0f));
-				ticksRemaining = MAX(0, MIN(ticksRemaining, GAMEMOVEMENT_DUCK_TICKS));
-				float flDuckSeconds = ticksRemaining * gpGlobals->interval_per_tick;
+				float flDuckMilliseconds = MAX( 0.0f, GAMEMOVEMENT_DUCK_TIME - ( float )player->m_Local.m_flDucktime );
+				float flDuckSeconds = flDuckMilliseconds * 0.001f;
 				
 				// Finish in duck transition when transition time is over, in "duck", in air.
 				if ( ( flDuckSeconds > TIME_TO_DUCK ) || bInDuck || bInAir )
@@ -4520,8 +4518,7 @@ void CGameMovement::Duck( void )
 				{
 					// Still under something where we can't unduck, so make sure we reset this timer so
 					//  that we'll unduck once we exit the tunnel, etc.
-					// Round duck time to nearest tick boundary
-				if ( fabs(player->m_Local.m_flDucktime - GAMEMOVEMENT_DUCK_TIME) > (gpGlobals->interval_per_tick * 1000.0f * 0.5f))
+					if ( player->m_Local.m_flDucktime != GAMEMOVEMENT_DUCK_TIME )
 					{
 						SetDuckedEyeOffset(1.0f);
 						player->m_Local.m_flDucktime = GAMEMOVEMENT_DUCK_TIME;

--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -4399,8 +4399,10 @@ void CGameMovement::Duck( void )
 			// The player is in duck transition and not duck-jumping.
 			if ( player->m_Local.m_bDucking && !bDuckJump && !bDuckJumpTime )
 			{
-				float flDuckMilliseconds = MAX( 0.0f, GAMEMOVEMENT_DUCK_TIME - ( float )player->m_Local.m_flDucktime );
-				float flDuckSeconds = flDuckMilliseconds * 0.001f;
+				// Convert duck time to ticks for consistent timing
+				int ticksRemaining = (int)((GAMEMOVEMENT_DUCK_TIME - player->m_Local.m_flDucktime) / (gpGlobals->interval_per_tick * 1000.0f));
+				ticksRemaining = MAX(0, MIN(ticksRemaining, GAMEMOVEMENT_DUCK_TICKS));
+				float flDuckSeconds = ticksRemaining * gpGlobals->interval_per_tick;
 				
 				// Finish in duck transition when transition time is over, in "duck", in air.
 				if ( ( flDuckSeconds > TIME_TO_DUCK ) || bInDuck || bInAir )
@@ -4518,7 +4520,8 @@ void CGameMovement::Duck( void )
 				{
 					// Still under something where we can't unduck, so make sure we reset this timer so
 					//  that we'll unduck once we exit the tunnel, etc.
-					if ( player->m_Local.m_flDucktime != GAMEMOVEMENT_DUCK_TIME )
+					// Round duck time to nearest tick boundary
+				if ( fabs(player->m_Local.m_flDucktime - GAMEMOVEMENT_DUCK_TIME) > (gpGlobals->interval_per_tick * 1000.0f * 0.5f))
 					{
 						SetDuckedEyeOffset(1.0f);
 						player->m_Local.m_flDucktime = GAMEMOVEMENT_DUCK_TIME;

--- a/src/game/shared/gamemovement.h
+++ b/src/game/shared/gamemovement.h
@@ -19,7 +19,9 @@
 #define CTEXTURESMAX		512			// max number of textures loaded
 #define CBTEXTURENAMEMAX	13			// only load first n chars of name
 
-#define GAMEMOVEMENT_DUCK_TIME				1000.0f		// ms
+// Calculate duck ticks to maintain 1000ms duck time at any tick rate
+#define GAMEMOVEMENT_DUCK_TICKS              (int)(1.0f / gpGlobals->interval_per_tick)
+#define GAMEMOVEMENT_DUCK_TIME              (GAMEMOVEMENT_DUCK_TICKS * gpGlobals->interval_per_tick * 1000.0f)
 #define GAMEMOVEMENT_JUMP_TIME				510.0f		// ms approx - based on the 21 unit height jump
 #define GAMEMOVEMENT_JUMP_HEIGHT			21.0f		// units
 #define GAMEMOVEMENT_TIME_TO_UNDUCK			( TIME_TO_UNDUCK * 1000.0f )		// ms

--- a/src/game/shared/gamemovement.h
+++ b/src/game/shared/gamemovement.h
@@ -19,9 +19,7 @@
 #define CTEXTURESMAX		512			// max number of textures loaded
 #define CBTEXTURENAMEMAX	13			// only load first n chars of name
 
-// Calculate duck ticks to maintain 1000ms duck time at any tick rate
-#define GAMEMOVEMENT_DUCK_TICKS              (int)(1.0f / gpGlobals->interval_per_tick)
-#define GAMEMOVEMENT_DUCK_TIME              (GAMEMOVEMENT_DUCK_TICKS * gpGlobals->interval_per_tick * 1000.0f)
+#define GAMEMOVEMENT_DUCK_TIME				1000.0f		// ms
 #define GAMEMOVEMENT_JUMP_TIME				510.0f		// ms approx - based on the 21 unit height jump
 #define GAMEMOVEMENT_JUMP_HEIGHT			21.0f		// units
 #define GAMEMOVEMENT_TIME_TO_UNDUCK			( TIME_TO_UNDUCK * 1000.0f )		// ms


### PR DESCRIPTION
Increased float rounding precision for the server from 12 to 16 bits for m_flDucktime to fix prediction errors.

With it being more precise, the rounded values are synced with the client, otherwise the float is rounded to values that can not align with the client.

This will mean increased network usage. I don't personally see much of a reason fixing the minor prediction errors that ``cl_showerror 2`` prints as there is no real downside in them.

Closes #115