### PR TITLE
fix: retain killstreaks with concommand `resupply`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -562,3 +562,5 @@ game/p4ss/cfg/settings.scr
 game/p4ss/screenshots/
 game/p4ss/screenshots/*
 .vscode/tasks.json
+jumpqol.inc
+jumpqol.sp

--- a/.gitignore
+++ b/.gitignore
@@ -562,5 +562,3 @@ game/p4ss/cfg/settings.scr
 game/p4ss/screenshots/
 game/p4ss/screenshots/*
 .vscode/tasks.json
-jumpqol.inc
-jumpqol.sp

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -7134,7 +7134,6 @@ void CTFPlayer::CheckInstantLoadoutRespawn( void )
 		}
 	}
 }
-
 void CTFPlayer::Resupply( void )
 {
 	// Must be alive
@@ -7157,8 +7156,39 @@ void CTFPlayer::Resupply( void )
 	if ( TFGameRules()->State_Get() == GR_STATE_TEAM_WIN && TFGameRules()->GetWinningTeam() != GetTeamNumber() ) 
 		return;
 
-	iLastWeapon = m_iLastWeaponSlot;
+	int iPlayerStreak = m_Shared.GetStreak( CTFPlayerShared::kTFStreak_Kills );
+	int iLastWeapon = m_iLastWeaponSlot;
+	
+	// Save kill streaks for all weapons
+	CUtlVector<int> weaponStreaks;
+	for (int i = 0; i < TF_WEAPON_COUNT; i++)
+	{
+		CTFWeaponBase *pWeapon = (CTFWeaponBase *)GetWeapon(i);
+		if (pWeapon)
+		{
+			weaponStreaks.AddToTail(pWeapon->GetKillStreak());
+		}
+		else
+		{
+			weaponStreaks.AddToTail(0);
+		}
+	}
+	
 	ForceRegenerateAndRespawn();
+	
+	// Restore player streak
+	m_Shared.SetStreak( CTFPlayerShared::kTFStreak_Kills, iPlayerStreak );
+	
+	// Restore kill streaks for all weapons
+	for (int i = 0; i < TF_WEAPON_COUNT && i < weaponStreaks.Count(); i++)
+	{
+		CTFWeaponBase *pWeapon = (CTFWeaponBase *)GetWeapon(i);
+		if (pWeapon)
+		{
+			pWeapon->SetKillStreak(weaponStreaks[i]);
+		}
+	}
+	
 	m_iLastWeaponSlot = iLastWeapon;
 }
 

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -1184,7 +1184,6 @@ private:
 	CTFPlayerClass		m_PlayerClass;
 	int					m_iLastWeaponFireUsercmd;				// Firing a weapon.  Last usercmd we shot a bullet on.
 	int					m_iLastWeaponSlot;				            // To save last switch between lives
-	int					iLastWeapon;
 	int					m_iLastSkin;
 	float				m_flLastDamageTime;
 	CNetworkVar( float, m_flMvMLastDamageTime );


### PR DESCRIPTION
Tested locally on itemtest, using bots and a killstreak weapon.
- After killing a bot, HUD showed 1KS
- After resupplying, scoreboard retained 1KS
- Killing another bot, killfeed and scoreboard incremented by one.

Resolves #162