### PR TITLE
Fix MOD_LAUNCHER macro for using SDK2013 Launcher

### DIFF
--- a/src/launcher_main/main.cpp
+++ b/src/launcher_main/main.cpp
@@ -88,13 +88,11 @@ static void *Launcher_GetProcAddress( void *pHandle, const char *pszName )
 
 static const AppId_t k_unSDK2013MPAppId = 243750;
 
-// #ifdef MOD_LAUNCHER
-// static const AppId_t k_unMyModAppid = MOD_APPID;
-// #else
-// static const AppId_t k_unMyModAppid = k_unSDK2013MPAppId;
-// #endif
-
-static const AppId_t k_unMyModAppid = 3554290;
+#ifdef MOD_LAUNCHER
+static const AppId_t k_unMyModAppid = MOD_APPID;
+#else
+static const AppId_t k_unMyModAppid = k_unSDK2013MPAppId;
+#endif
 
 static bool s_bInittedSteam = false;
 


### PR DESCRIPTION
<!--
Ensure your contributions and code are your own original contributions, and that you are giving them over to us (passtime.tf) to use in this project and any other subprojects based on this source code.
-->

Disabling the MOD_LAUNCHER VPC conditional has no effect, as the pertinent code that uses SDK2013's App ID when it is disabled is commented out. This PR fixes that.

Resolves https://github.com/p4sstime/p4ss/issues/179

