### PR TITLE
Revert to 66tick

### DIFF
--- a/game/p4ss/cfg/autoexec.cfg
+++ b/game/p4ss/cfg/autoexec.cfg
@@ -15,8 +15,9 @@ mp_decals 									25		// ^
 cl_interp									0		// All of this sets interp/lerp to 15.2ms
 cl_interp_ratio								0		// ^
 rate										786432	// ^
-cl_updaterate								128		// ^
-cl_cmdrate									128		// ^
+cl_updaterate								66		// ^
+cl_cmdrate									66		// ^
 
-sv_maxupdaterate 128
-sv_maxcmdrate 128
+sv_maxupdaterate 66
+sv_maxcmdrate 66
+

--- a/src/public/const.h
+++ b/src/public/const.h
@@ -28,7 +28,7 @@
 #define CLIENTNAME_TIMED_OUT "%s timed out"
 
 // This is the default, see shareddefs.h for mod-specific value, which can override this
-#define DEFAULT_TICK_INTERVAL	(0.0078125)				// 15 msec is the default
+#define DEFAULT_TICK_INTERVAL	(0.015)				// 15 msec is the default
 #define MINIMUM_TICK_INTERVAL   (0.001)
 #define MAXIMUM_TICK_INTERVAL	(0.1)
 


### PR DESCRIPTION
changed tickrate back to 0.015 (66tick) and changed rates in autoexec to match
as discussed, high tickrate support can come later when we can test more easily and fix inconsistencies