### PR TITLE
Fix weapons wiping velocity for ragdolls

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -1347,7 +1347,7 @@ void CTFWeaponBase::OnActiveStateChanged( int iOldState )
 
 	// Check for a speed mod change.
 	CTFPlayer *pPlayer = ToTFPlayer( GetOwner() );
-	if ( pPlayer )
+	if ( pPlayer && pPlayer->IsAlive() )
 	{
 		pPlayer->TeamFortress_SetSpeed();
 	}


### PR DESCRIPTION
https://github.com/ValveSoftware/source-sdk-2013/pull/1242
Causes ragdolls to properly inherit momentum on death (similar to sm_pt_suicide) rather than stopping and falling. 
