### PR TITLE
Allow caber to minicrit during charge

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -6109,9 +6109,9 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 					eDamageBonusCond = TF_COND_OFFENSEBUFF;
 				}
 			}
-			else if ( pTFAttacker && (bitsDamage & DMG_RADIUS_MAX) && pWeapon && ( (pWeapon->GetWeaponID() == TF_WEAPON_SWORD) || (pWeapon->GetWeaponID() == TF_WEAPON_BOTTLE)|| (pWeapon->GetWeaponID() == TF_WEAPON_WRENCH) ) )
+			else if ( pTFAttacker && ( bitsDamage & DMG_RADIUS_MAX ) && pWeapon && ( ( pWeapon->GetWeaponID() == TF_WEAPON_SWORD ) || ( pWeapon->GetWeaponID() == TF_WEAPON_BOTTLE ) || ( pWeapon->GetWeaponID() == TF_WEAPON_STICKBOMB ) || ( pWeapon->GetWeaponID() == TF_WEAPON_WRENCH ) ) )
 			{
-				// First sword or bottle attack after a charge is a mini-crit.
+				// First sword, bottle, or caber attack after a charge is a mini-crit.
 				bAllSeeCrit = true;
 				info.SetCritType( CTakeDamageInfo::CRIT_MINI );
 				eBonusEffect = kBonusEffect_MiniCrit;

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -5679,7 +5679,7 @@ void CTFGameRules::RadiusDamage( CTFRadiusDamageInfo &info )
 //-----------------------------------------------------------------------------
 void CTFRadiusDamageInfo::CalculateFalloff( void )
 {
-	if ( dmgInfo->GetDamageType() & DMG_RADIUS_MAX )
+	if ( dmgInfo->GetDamageCustom() != TF_DMG_CUSTOM_STICKBOMB_EXPLOSION && dmgInfo->GetDamageType() & DMG_RADIUS_MAX )
 		flFalloff = 0.f;
 	else if ( dmgInfo->GetDamageType() & DMG_HALF_FALLOFF )
 		flFalloff = 0.5f;

--- a/src/game/shared/tf/tf_weapon_bottle.cpp
+++ b/src/game/shared/tf/tf_weapon_bottle.cpp
@@ -257,6 +257,8 @@ void CTFStickBomb::Smack( void )
 			int dmgType = DMG_BLAST | DMG_USEDISTANCEMOD;
 			if ( IsCurrentAttackACrit() )
 				dmgType |= DMG_CRITICAL;
+            else if ( m_bMiniCrit )
+                dmgType |= DMG_RADIUS_MAX;
 
 			CTakeDamageInfo info( pTFPlayer, pTFPlayer, this, explosion, explosion, 75.0f, dmgType, TF_DMG_CUSTOM_STICKBOMB_EXPLOSION, &explosion );
 			CTFRadiusDamageInfo radiusinfo( &info, explosion, 100.f );

--- a/src/game/shared/tf/tf_weapon_bottle.cpp
+++ b/src/game/shared/tf/tf_weapon_bottle.cpp
@@ -257,8 +257,8 @@ void CTFStickBomb::Smack( void )
 			int dmgType = DMG_BLAST | DMG_USEDISTANCEMOD;
 			if ( IsCurrentAttackACrit() )
 				dmgType |= DMG_CRITICAL;
-            else if ( m_bMiniCrit )
-                dmgType |= DMG_RADIUS_MAX;
+			else if ( m_bMiniCrit )
+				dmgType |= DMG_RADIUS_MAX;
 
 			CTakeDamageInfo info( pTFPlayer, pTFPlayer, this, explosion, explosion, 75.0f, dmgType, TF_DMG_CUSTOM_STICKBOMB_EXPLOSION, &explosion );
 			CTFRadiusDamageInfo radiusinfo( &info, explosion, 100.f );


### PR DESCRIPTION
This also allows the explosion damage to minicrit, but this was changed in a commit which we can revert if it's a balance concern

Closes #202 