### PR TITLE
Fix MOD_LAUNCHER macro to use SDK2013 AppId

### DIFF
--- a/src/launcher_main/launcher_main.vpc
+++ b/src/launcher_main/launcher_main.vpc
@@ -47,7 +47,8 @@ $Configuration
 
 	$Linker
 	{
-		$SystemLibraries				"SDL2" [$MOD_LAUNCHER && $LINUXALL]
+		// $SystemLibraries				"SDL2" [$MOD_LAUNCHER && $LINUXALL]
+		$SystemLibraries				"SDL2" [$LINUXALL] // lucy: this doesn't link on Linux with mod_launcher disabled?
 	}
 }
 

--- a/src/launcher_main/main.cpp
+++ b/src/launcher_main/main.cpp
@@ -88,13 +88,11 @@ static void *Launcher_GetProcAddress( void *pHandle, const char *pszName )
 
 static const AppId_t k_unSDK2013MPAppId = 243750;
 
-// #ifdef MOD_LAUNCHER
-// static const AppId_t k_unMyModAppid = MOD_APPID;
-// #else
-// static const AppId_t k_unMyModAppid = k_unSDK2013MPAppId;
-// #endif
-
-static const AppId_t k_unMyModAppid = 3554290;
+#ifdef MOD_LAUNCHER
+static const AppId_t k_unMyModAppid = MOD_APPID;
+#else
+static const AppId_t k_unMyModAppid = k_unSDK2013MPAppId;
+#endif
 
 static bool s_bInittedSteam = false;
 


### PR DESCRIPTION
- **Fix MOD_LAUNCHER macro for using SDK2013 Launcher**
- **chore: link issue on linux**

<!--
Ensure your contributions and code are your own original contributions, and that you are giving them over to us (passtime.tf) to use in this project and any other subprojects based on this source code.
-->

# Description
Reopening of #180
