### PR TITLE
fix: lag-compensated charge turn (fixes #36)

### DIFF
--- a/src/game/client/tf/tf_input_main.cpp
+++ b/src/game/client/tf/tf_input_main.cpp
@@ -7,13 +7,19 @@
 #include "cbase.h"
 #include "kbutton.h"
 #include "input.h"
+#include "usercmd.h"
+#include "in_buttons.h"
+#include "inetchannelinfo.h"
 
 #include "c_tf_player.h"
 #include "cam_thirdperson.h"
+#include "tf_gamerules.h"
 
+extern ConVar 		tf_charge_turn_debug_client;
 extern ConVar		thirdperson_platformer;
 extern ConVar		cam_idealyaw;
 extern ConVar		cl_yawspeed;
+extern ConVar		tf_charge_turn_rate; // Base cap for charge turning
 extern kbutton_t	in_left;
 extern kbutton_t	in_right;
 extern CThirdPersonManager g_ThirdPersonManager;
@@ -43,18 +49,213 @@ static CTFInput g_Input;
 IInput *input = ( IInput * )&g_Input;
 
 //-----------------------------------------------------------------------------
+// Purpose: Client-side charge state tracking for immediate turn capping
+//-----------------------------------------------------------------------------
+static bool s_bClientChargeActive = false;
+static float s_flClientChargeStartTime = 0.0f;
+static float s_flPredictiveClampDuration = 0.0f; // dynamically set from latency
+static float s_flLastChargeInputTime = 0.0f;
+static int s_nPreviousButtons = 0;
+static int  s_nLastClampFrame = -1;
+static bool s_bClampCached   = false;
+
+//-----------------------------------------------------------------------------
+// Purpose: Helper function to determine if we should apply charge turn capping
+// This includes both confirmed server state and immediate client-side input detection
+//-----------------------------------------------------------------------------
+static bool ShouldApplyChargeClamping( CTFPlayer *pPlayer )
+{
+	if ( !pPlayer )
+		return false;
+
+	int currFrame = gpGlobals->framecount;
+	if ( currFrame == s_nLastClampFrame )
+		return s_bClampCached;
+
+	
+	// Debug: Log function calls
+	static float s_flLastDebugTime = 0.0f;
+	
+	// Cancel predictive clamp immediately if the player swings primary (melee),
+	// matching server-side EndClassSpecialSkill()
+	if ( pPlayer->m_nButtons & IN_ATTACK )
+	{
+		s_bClientChargeActive = false;
+		s_nLastClampFrame = currFrame;
+		s_bClampCached = false;
+		return false;
+	}
+	if ( tf_charge_turn_debug_client.GetBool() && (gpGlobals->curtime - s_flLastDebugTime) > 0.1f )
+	{
+		DevMsg("[ShouldApplyChargeClamping] Called - server charge: %s, client active: %s\n", 
+			pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) ? "YES" : "NO",
+			s_bClientChargeActive ? "YES" : "NO");
+		s_flLastDebugTime = gpGlobals->curtime;
+	}
+	
+
+	// Always clamp if server has confirmed we're charging
+	if ( pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+	{
+		// Server confirmed charge, make sure our client state is active
+		if ( !s_bClientChargeActive )
+		{
+			s_bClientChargeActive = true;
+			s_flClientChargeStartTime = gpGlobals->curtime;
+			if ( tf_charge_turn_debug_client.GetBool() )
+			{
+				DevMsg("[ShouldApplyChargeClamping] Server confirmed charge - activating client state\n");
+			}
+		}
+		s_nLastClampFrame = currFrame;
+		s_bClampCached = true;
+		return true;
+	}
+	
+	// Check if we have a demo shield equipped
+	if ( !pPlayer->m_Shared.HasDemoShieldEquipped() )
+	{
+		s_bClientChargeActive = false;
+		s_nLastClampFrame = currFrame;
+		s_bClampCached = false;
+		return false;
+	}
+	
+	// Check if charge input was recently pressed (immediate client-side detection)
+	C_BasePlayer *pLocalPlayer = C_BasePlayer::GetLocalPlayer();
+	if ( pLocalPlayer && pLocalPlayer == pPlayer )
+	{
+		// Debug: Log button state changes
+		if ( tf_charge_turn_debug_client.GetBool() )
+		{
+			if ( (pPlayer->m_nButtons & IN_ATTACK2) != (s_nPreviousButtons & IN_ATTACK2) )
+			{
+				DevMsg("[BUTTON DEBUG] IN_ATTACK2 changed: %s -> %s (class: %d)\n",
+					(s_nPreviousButtons & IN_ATTACK2) ? "PRESSED" : "RELEASED",
+					(pPlayer->m_nButtons & IN_ATTACK2) ? "PRESSED" : "RELEASED",
+					pPlayer->GetPlayerClass()->GetClassIndex());
+			}
+		}
+		
+		// Check if IN_ATTACK2 is currently pressed (charge input for demoman)
+		if ( (pPlayer->m_nButtons & IN_ATTACK2) && pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN )
+		{
+			// Check if this is a new press (not held from previous frame)
+			if ( !(s_nPreviousButtons & IN_ATTACK2) )
+			{
+				// Only begin predictive clamping if shield has a full charge available
+				if ( pPlayer->m_Shared.GetDemomanChargeMeter() >= 100.f )
+				{
+					// Fresh charge input detected - start immediate clamping
+					s_bClientChargeActive = true;
+					s_flClientChargeStartTime = gpGlobals->curtime;
+					s_flLastChargeInputTime = gpGlobals->curtime;
+					
+					// Determine clamp duration based on current latency (round-trip) + 50ms safety buffer
+					INetChannelInfo *nci = engine->GetNetChannelInfo();
+					float flLatency = 0.0f;
+					if ( nci )
+					{
+						flLatency = nci->GetAvgLatency( FLOW_OUTGOING ) + nci->GetAvgLatency( FLOW_INCOMING );
+					}
+					s_flPredictiveClampDuration = flLatency + 0.05f; // add 50ms
+				}
+				else if ( tf_charge_turn_debug_client.GetBool() )
+				{
+					DevMsg("[CLIENT IMMEDIATE] Charge input detected but meter not full (%.1f) – no predictive clamp\n", pPlayer->m_Shared.GetDemomanChargeMeter());
+				}
+				
+				if ( tf_charge_turn_debug_client.GetBool() )
+				{
+					DevMsg("[CLIENT IMMEDIATE] Charge input detected - starting immediate turn clamping\n");
+				}
+			}
+		}
+
+		
+		// Always update previous buttons for next frame
+		s_nPreviousButtons = pPlayer->m_nButtons;
+	}
+	
+	// If we have active client-side charge state, keep clamping for a short duration
+	// This handles the gap between input and server confirmation
+	if ( s_bClientChargeActive )
+	{
+		float flTimeSinceStart = gpGlobals->curtime - s_flClientChargeStartTime;
+		
+		// Keep clamping for the latency-adjusted duration
+		if ( flTimeSinceStart < s_flPredictiveClampDuration )
+		{
+			s_nLastClampFrame = currFrame;
+		s_bClampCached = true;
+		return true;
+		}
+		else
+		{
+			// Timeout - server didn't confirm charge, stop client-side clamping
+			s_bClientChargeActive = false;
+			if ( tf_charge_turn_debug_client.GetBool() )
+			{
+				DevMsg("[CLIENT IMMEDIATE] Charge clamping timeout - stopping client prediction\n");
+			}
+		}
+	}
+	
+	s_nLastClampFrame = currFrame;
+		s_bClampCached = false;
+		return false;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Predictive turn-rate cap used before the server confirms the charge
+//-----------------------------------------------------------------------------
+static float PredictiveCapChargeTurnRate( CTFPlayer *pPlayer, float flYawDelta )
+{
+	// Use the same base convar as the real cap function
+	float flBaseCap = tf_charge_turn_rate.GetFloat();
+
+	// NOTE: We purposely skip the attribute hook here; it will be applied after
+	// the server confirms the charge.  This keeps the client code simple while
+	// still preventing players from over-turning in the early frames.
+	float flMaxYawDelta = flBaseCap * gpGlobals->frametime / TICK_INTERVAL;
+
+	if ( tf_charge_turn_debug_client.GetBool() )
+	{
+		DevMsg("[CLIENT PREDICT] yaw delta %.2f, max allowed %.2f (cap %.2f, frametime %.4f)\n",
+			flYawDelta, flMaxYawDelta, flBaseCap, gpGlobals->frametime );
+	}
+
+	if ( flYawDelta > flMaxYawDelta )
+		return flMaxYawDelta;
+	else if ( flYawDelta < -flMaxYawDelta )
+		return -flMaxYawDelta;
+
+	return flYawDelta;
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Cap yaw movement
 //-----------------------------------------------------------------------------
 float CTFInput::CAM_CapYaw( float fVal ) const
 {
 	CTFPlayer *pPlayer = C_TFPlayer::GetLocalTFPlayer();
-	if ( !pPlayer )
-		return fVal;
-
-	if ( pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+	
+	if ( ShouldApplyChargeClamping( pPlayer ) )
 	{
-		// Use the unified charge turn rate limiter
-		return pPlayer->m_Shared.CapChargeTurnRate( fVal );
+		float flClamped;
+		if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+		{
+			flClamped = pPlayer->m_Shared.CapChargeTurnRate( fVal );
+		}
+		else
+		{
+			flClamped = PredictiveCapChargeTurnRate( pPlayer, fVal );
+		}
+		if ( tf_charge_turn_debug_client.GetBool() && fabs(flClamped - fVal) > 0.01f )
+		{
+			DevMsg("[CAM_CapYaw] Clamped %.3f -> %.3f\n", fVal, flClamped);
+		}
+		return flClamped;
 	}
 
 	return fVal;
@@ -93,11 +294,18 @@ void CTFInput::AdjustYaw( float speed, QAngle& viewangles )
 		float yaw_right = speed*cl_yawspeed.GetFloat() * KeyState( &in_right ) * frameTime * ( 1.0f / TICK_INTERVAL );
 		float yaw_left = speed*cl_yawspeed.GetFloat() * KeyState( &in_left ) * frameTime * ( 1.0f / TICK_INTERVAL );
 		
-		if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+		if ( ShouldApplyChargeClamping( pPlayer ) )
 		{
-			// Cap the keyboard turning using unified function
-			yaw_right = pPlayer->m_Shared.CapChargeTurnRate( yaw_right );
-			yaw_left = pPlayer->m_Shared.CapChargeTurnRate( yaw_left );
+			if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+			{
+				yaw_right = pPlayer->m_Shared.CapChargeTurnRate( yaw_right );
+				yaw_left  = pPlayer->m_Shared.CapChargeTurnRate( yaw_left );
+			}
+			else
+			{
+				yaw_right = PredictiveCapChargeTurnRate( pPlayer, yaw_right );
+				yaw_left  = PredictiveCapChargeTurnRate( pPlayer, yaw_left );
+			}
 		}
 		
 		// Apply keyboard turn
@@ -110,13 +318,20 @@ void CTFInput::AdjustYaw( float speed, QAngle& viewangles )
 	
 	// For mouse movement, the engine has already applied the changes to viewangles
 	// We need to check if the mouse change + keyboard change exceeds the cap
-	if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+	if ( ShouldApplyChargeClamping( pPlayer ) )
 	{
 		// Calculate the total angle change from previous frame
 		float mouseYawChange = AngleDiff(viewangles[YAW], prevViewangles[YAW]) - totalYawChange;
 		
-		// Cap mouse movement
-		float cappedMouseYaw = pPlayer->m_Shared.CapChargeTurnRate(mouseYawChange);
+		float cappedMouseYaw;
+		if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+		{
+			cappedMouseYaw = pPlayer->m_Shared.CapChargeTurnRate( mouseYawChange );
+		}
+		else
+		{
+			cappedMouseYaw = PredictiveCapChargeTurnRate( pPlayer, mouseYawChange );
+		}
 		
 		// Apply capped mouse movement
 		if (cappedMouseYaw != mouseYawChange)
@@ -154,10 +369,16 @@ float CTFInput::JoyStickAdjustYaw( float flSpeed )
 	if ( flSpeed && !(in_strafe.state & 1) )
 	{
 		CTFPlayer *pPlayer = C_TFPlayer::GetLocalTFPlayer();
-		if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+		if ( ShouldApplyChargeClamping( pPlayer ) )
 		{
-			// Use the unified charge turn rate limiter
-			flSpeed = pPlayer->m_Shared.CapChargeTurnRate( flSpeed );
+			if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+			{
+				flSpeed = pPlayer->m_Shared.CapChargeTurnRate( flSpeed );
+			}
+			else
+			{
+				flSpeed = PredictiveCapChargeTurnRate( pPlayer, flSpeed );
+			}
 		}
 	}
 

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1090,6 +1090,7 @@ CTFPlayer::CTFPlayer()
 	SetRespawnOverride( -1.f, NULL_STRING );
 
 	m_qPreviousChargeEyeAngle.Init();
+	m_nPreviousChargeCommandNumber = 0;
 
 	m_vHalloweenKartPush.Zero();
 	m_flHalloweenKartPushEventTime = 0.f;

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -1311,6 +1311,7 @@ public:
 	CountdownTimer m_playerMovementStuckTimer;			// for destroying stuck bots in MvM
 
 	QAngle				m_qPreviousChargeEyeAngle;		// Previous EyeAngles to compute deltas for legal mouse movement
+	int					m_nPreviousChargeCommandNumber;	// Previous command number for lag compensation
 private:
 
 	//=============================================================================

--- a/src/game/server/tf/tf_playermove.cpp
+++ b/src/game/server/tf/tf_playermove.cpp
@@ -12,6 +12,7 @@
 #include "ipredictionsystem.h"
 #include "tf_player.h"
 
+extern ConVar tf_charge_turn_debug;
 
 static CMoveData g_MoveData;
 CMoveData *g_pMoveData = &g_MoveData;
@@ -81,29 +82,68 @@ void CTFPlayerMove::SetupMove( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 			}
 		}
 
-		// Server-side charge turn capping
+		// Server-side charge turn capping with proper lag compensation
 		if ( pTFPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 		{
-			// Calculate yaw delta between current view and the previous charge view angle.
-			float flYawDelta = AngleDiff( ucmd->viewangles[YAW], pTFPlayer->m_qPreviousChargeEyeAngle[YAW] );
+			// Cache the original (unmodified) view angles for history tracking
+			QAngle qOriginalViewAngles = ucmd->viewangles;
+			// Calculate yaw delta between current raw view and the previous *raw* charge view angle.
+			float flYawDelta = AngleDiff( qOriginalViewAngles[YAW], pTFPlayer->m_qPreviousChargeEyeAngle[YAW] );
 			
-			// Clamp the yaw change using the unified function.
-			float flCappedYawDelta = pTFPlayer->m_Shared.CapChargeTurnRate( flYawDelta );
+			// Calculate the actual time difference between user commands for proper lag compensation
+			float flTimeDelta = TICK_INTERVAL;
+			int nCommandDiff = 1;
+			if ( pTFPlayer->m_nPreviousChargeCommandNumber > 0 )
+			{
+				nCommandDiff = ucmd->command_number - pTFPlayer->m_nPreviousChargeCommandNumber;
+				if ( nCommandDiff > 0 && nCommandDiff < 64 ) // Sanity check to prevent overflow issues
+				{
+					flTimeDelta = nCommandDiff * TICK_INTERVAL;
+				}
+				else
+				{
+					nCommandDiff = 1; // Fallback to single tick
+				}
+			}
+			
+			if ( tf_charge_turn_debug.GetInt() >= 1 )
+			{
+				DevMsg("[PLAYERMOVE] Player charging: cmd %d->%d (diff %d), yaw %.2f->%.2f (delta %.2f), timeDelta %.4f\n",
+					pTFPlayer->m_nPreviousChargeCommandNumber, ucmd->command_number, nCommandDiff,
+					pTFPlayer->m_qPreviousChargeEyeAngle[YAW], ucmd->viewangles[YAW], flYawDelta, flTimeDelta);
+			}
+			
+			// Clamp the yaw change using the unified function with proper time delta.
+			float flCappedYawDelta = pTFPlayer->m_Shared.CapChargeTurnRate( flYawDelta, flTimeDelta );
 
 			// Only clamp if the yaw difference exceeds the cap by more than the tolerance.
 			if ( fabs(flYawDelta) > tf_charge_turn_tolerance.GetFloat() * fabs(flCappedYawDelta) )
 			{
+				if ( tf_charge_turn_debug.GetInt() >= 1 )
+				{
+					DevMsg("[PLAYERMOVE] APPLYING SERVER CLAMP: yaw %.2f -> %.2f (tolerance %.2f exceeded)\n",
+						ucmd->viewangles[YAW], pTFPlayer->m_qPreviousChargeEyeAngle[YAW] + flCappedYawDelta, tf_charge_turn_tolerance.GetFloat());
+				}
 				// Adjust the view angle based on the capped delta.
 				ucmd->viewangles[YAW] = pTFPlayer->m_qPreviousChargeEyeAngle[YAW] + flCappedYawDelta;
 				pTFPlayer->SnapEyeAngles( ucmd->viewangles );
 			}
+			else if ( tf_charge_turn_debug.GetInt() >= 2 )
+			{
+				DevMsg("[PLAYERMOVE] No server clamp needed: delta %.2f within tolerance of capped %.2f\n", flYawDelta, flCappedYawDelta);
+			}
 			
-			// Store the current view angle for the next tick.
+			// Store the **final applied** eye angle (post-clamp) so that next tick's
+			// comparison reflects what the player actually saw on the server. This
+			// avoids small opposite-direction deltas that appear when we kept the
+			// unclamped value.
 			pTFPlayer->m_qPreviousChargeEyeAngle = ucmd->viewangles;
+			pTFPlayer->m_nPreviousChargeCommandNumber = ucmd->command_number;
 		}
 		else
 		{
 			pTFPlayer->m_qPreviousChargeEyeAngle = pTFPlayer->EyeAngles();
+			pTFPlayer->m_nPreviousChargeCommandNumber = 0; // Reset for next charge
 		}
 	}
 

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -6079,6 +6079,10 @@ void CTFPlayerShared::EndCharge()
 // New convar to control charge turn rate. Default is same as vanilla TF2.
 ConVar tf_charge_turn_rate("tf_charge_turn_rate", "0.45", FCVAR_REPLICATED | FCVAR_CHEAT, "Base turn rate cap for demoman charge in degrees per tick");
 
+// Debug convars for charge turn capping
+ConVar tf_charge_turn_debug("tf_charge_turn_debug", "0", FCVAR_REPLICATED | FCVAR_CHEAT, "Debug charge turn capping: 1=basic, 2=verbose");
+ConVar tf_charge_turn_debug_client("tf_charge_turn_debug_client", "0", FCVAR_REPLICATED | FCVAR_CHEAT, "Debug client-side charge turn capping");
+
 //-----------------------------------------------------------------------------
 // Purpose: Unified function to cap turning rate for charge regardless of input method
 // Input:   Raw yaw change in degrees
@@ -6087,7 +6091,13 @@ ConVar tf_charge_turn_rate("tf_charge_turn_rate", "0.45", FCVAR_REPLICATED | FCV
 float CTFPlayerShared::CapChargeTurnRate(float flYawDelta) const
 {
 	if (!InCond(TF_COND_SHIELD_CHARGE))
+	{
+		if (tf_charge_turn_debug_client.GetBool() && fabs(flYawDelta) > 0.01f)
+		{
+			DevMsg("[CLIENT] Not charging, yaw delta %.2f passed through\n", flYawDelta);
+		}
 		return flYawDelta;
+	}
 
 	// Base turn rate cap in degrees per tick
 	float flBaseCap = tf_charge_turn_rate.GetFloat();
@@ -6097,11 +6107,80 @@ float CTFPlayerShared::CapChargeTurnRate(float flYawDelta) const
 
 	float flMaxYawDelta = flBaseCap * gpGlobals->frametime / TICK_INTERVAL;
 	
+	if (tf_charge_turn_debug_client.GetBool())
+	{
+		DevMsg("[CLIENT] Charging: yaw delta %.2f, max allowed %.2f (cap %.2f, frametime %.4f)\n", 
+			flYawDelta, flMaxYawDelta, flBaseCap, gpGlobals->frametime);
+	}
+	
 	// Apply the cap
 	if (flYawDelta > flMaxYawDelta)
+	{
+		if (tf_charge_turn_debug_client.GetBool())
+			DevMsg("[CLIENT] Capped positive yaw: %.2f -> %.2f\n", flYawDelta, flMaxYawDelta);
 		return flMaxYawDelta;
+	}
 	else if (flYawDelta < -flMaxYawDelta)
+	{
+		if (tf_charge_turn_debug_client.GetBool())
+			DevMsg("[CLIENT] Capped negative yaw: %.2f -> %.2f\n", flYawDelta, -flMaxYawDelta);
 		return -flMaxYawDelta;
+	}
+	
+	return flYawDelta;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Lag-compensated version for server-side turn rate capping
+// Input:   Raw yaw change in degrees, time delta between commands
+// Output:  Capped yaw change in degrees
+//-----------------------------------------------------------------------------
+float CTFPlayerShared::CapChargeTurnRate(float flYawDelta, float flTimeDelta) const
+{
+	if (!InCond(TF_COND_SHIELD_CHARGE))
+	{
+		if (tf_charge_turn_debug.GetInt() >= 2 && fabs(flYawDelta) > 0.01f)
+		{
+			DevMsg("[SERVER] Not charging, yaw delta %.2f passed through (timeDelta %.4f)\n", flYawDelta, flTimeDelta);
+		}
+		return flYawDelta;
+	}
+
+	// Base turn rate cap in degrees per tick
+	float flBaseCap = tf_charge_turn_rate.GetFloat();
+
+	// Apply charge_turn_control attribute
+	CALL_ATTRIB_HOOK_FLOAT_ON_OTHER(m_pOuter, flBaseCap, charge_turn_control);
+
+	// Use the actual time delta instead of server frametime for proper lag compensation
+	float flMaxYawDelta = flBaseCap * flTimeDelta / TICK_INTERVAL;
+	
+	if (tf_charge_turn_debug.GetInt() >= 1)
+	{
+		DevMsg("[SERVER] Charging: yaw delta %.2f, max allowed %.2f (cap %.2f, timeDelta %.4f, ticks %.1f)\n", 
+			flYawDelta, flMaxYawDelta, flBaseCap, flTimeDelta, flTimeDelta / TICK_INTERVAL);
+	}
+	
+	// Apply the cap
+	if (flYawDelta > flMaxYawDelta)
+	{
+		if (tf_charge_turn_debug.GetInt() >= 1)
+			DevMsg("[SERVER] LAG COMP CAPPED positive yaw: %.2f -> %.2f (saved %.2f degrees)\n", 
+				flYawDelta, flMaxYawDelta, flYawDelta - flMaxYawDelta);
+		return flMaxYawDelta;
+	}
+	else if (flYawDelta < -flMaxYawDelta)
+	{
+		if (tf_charge_turn_debug.GetInt() >= 1)
+			DevMsg("[SERVER] LAG COMP CAPPED negative yaw: %.2f -> %.2f (saved %.2f degrees)\n", 
+				flYawDelta, -flMaxYawDelta, fabs(flYawDelta) - flMaxYawDelta);
+		return -flMaxYawDelta;
+	}
+	
+	if (tf_charge_turn_debug.GetInt() >= 2)
+	{
+		DevMsg("[SERVER] No capping needed, yaw delta %.2f within limit %.2f\n", flYawDelta, flMaxYawDelta);
+	}
 	
 	return flYawDelta;
 }

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -531,6 +531,7 @@ public:
 	float	GetDemomanChargeMeter() const		{ return m_flChargeMeter; }
 	void	EndCharge( void ); 
 	float	CapChargeTurnRate(float flYawDelta) const;
+	float	CapChargeTurnRate(float flYawDelta, float flTimeDelta) const;
 	void	SetDemomanChargeMeter( float val )  { m_flChargeMeter = Clamp( val, 0.0f, 100.0f); }
 	void	CalcChargeCrit( bool bForceCrit=false );
 	bool	HasDemoShieldEquipped() const;


### PR DESCRIPTION
Charge turn cap is more robust with latency.

Server-side

- Added CTFPlayer::m_nPreviousChargeCommandNumber to track last processed cmd.
- CTFPlayerShared::CapChargeTurnRate() overload accepts flTimeDelta and scales the cap by real cmd interval.
- Computes delta ticks (command_number diff) and passes accurate flTimeDelta, mitigating over-clamping.

Client-side

- Immediate predictive clamping in tf_input_main.cpp:
  - Cap aim turn speed for RTT + 50 ms until server reply.
  - Use ShouldApplyChargeClamping() across all input methods.
  
  fixes #36 
