### PR TITLE
Adjust tf_charge_turn_rate

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -6077,7 +6077,7 @@ void CTFPlayerShared::EndCharge()
 }
 
 // New convar to control charge turn rate. Default is same as vanilla TF2.
-ConVar tf_charge_turn_rate("tf_charge_turn_rate", "0.45", FCVAR_REPLICATED | FCVAR_CHEAT, "Base turn rate cap for demoman charge in degrees per tick");
+ConVar tf_charge_turn_rate("tf_charge_turn_rate", "1.0", FCVAR_REPLICATED | FCVAR_CHEAT, "Base turn rate cap for demoman charge in degrees per tick");
 
 //-----------------------------------------------------------------------------
 // Purpose: Unified function to cap turning rate for charge regardless of input method


### PR DESCRIPTION
Adjusted the charge turn rate to better match the maximum turn rate achieved in TF2 with 60fps and `m_filter 1`.

Fixes #249