### PR TITLE
Add bot_teleport_to_me command and allow using player index in bot commands

### DIFF
--- a/src/game/server/tf/tf_bot_temp.cpp
+++ b/src/game/server/tf/tf_bot_temp.cpp
@@ -102,12 +102,23 @@ void GetBotsFromCommand( const CCommand &args, int iArgsRequired, const char *ps
 		}
 		return;
 	}
+    char *endptr = nullptr;
+    int idx = strtol(pszBotName, &endptr, 10);
+    if (endptr && *endptr == '\0' && idx > 0 && idx <= gpGlobals->maxClients)
+    {
+        CTFPlayer *pBot = ToTFPlayer( UTIL_PlayerByIndex( idx ) );
+        if ( pBot && pBot->IsFakeClient() )
+        {
+            botVector->AddToTail( pBot );
+            return;
+        }
+    }
 
 	// get the bot's player object
 	CTFPlayer *pBot = ToTFPlayer( UTIL_PlayerByName( pszBotName ) );
 	if ( !pBot || !pBot->IsFakeClient() )
 	{
-		Msg( "No bot with name %s\n", args[1] );
+		Msg( "No bot with name or index %s\n", args[1] );
 		return;
 	}
 
@@ -1380,6 +1391,25 @@ CON_COMMAND_F( bot_teleport, "Teleport the specified bot to the specified positi
 	
 }
 
+CON_COMMAND_F( bot_teleport_to_me, "Teleport the specified bot to your location. Usage: bot_teleport_to_me <bot name or index>", FCVAR_CHEAT )
+{
+    CUtlVector< CTFPlayer* > botVector;
+    GetBotsFromCommand( args, 2, "Usage: bot_teleport_to_me <bot name>", &botVector );
+    if ( botVector.IsEmpty() )
+        return;
+
+    CBasePlayer *pPlayer = UTIL_GetCommandClient();
+    if ( !pPlayer )
+        return;
+
+    Vector vecPos = pPlayer->GetAbsOrigin();
+    QAngle vecAng = pPlayer->EyeAngles();
+
+    FOR_EACH_VEC( botVector, i )
+    {
+        botVector[i]->Teleport( &vecPos, &vecAng, NULL );
+    }
+}
 //------------------------------------------------------------------------------
 // Purpose: Force the specified bot to create & equip an item
 //------------------------------------------------------------------------------

--- a/src/game/server/tf/tf_bot_temp.cpp
+++ b/src/game/server/tf/tf_bot_temp.cpp
@@ -1410,6 +1410,38 @@ CON_COMMAND_F( bot_teleport_to_me, "Teleport the specified bot to your location.
         botVector[i]->Teleport( &vecPos, &vecAng, NULL );
     }
 }
+
+CON_COMMAND_F( bot_teleport_to_aim, "Teleport the specified bot to your location. Usage: bot_teleport_to_aim <bot name or index>", FCVAR_CHEAT )
+{
+    CUtlVector< CTFPlayer* > botVector;
+    GetBotsFromCommand( args, 2, "Usage: bot_teleport_to_aim <bot name or index>", &botVector );
+    if ( botVector.IsEmpty() )
+        return;
+
+    CBasePlayer *pPlayer = UTIL_GetCommandClient();
+    if ( !pPlayer )
+        return;
+
+    trace_t tr;
+    Vector forward;
+    pPlayer->EyeVectors( &forward );
+    UTIL_TraceLine(
+        pPlayer->EyePosition(),
+        pPlayer->EyePosition() + forward * MAX_TRACE_LENGTH,
+        MASK_SOLID,
+        pPlayer,
+        COLLISION_GROUP_NONE,
+        &tr
+    );
+
+    Vector vecPos = (tr.fraction < 1.0f) ? tr.endpos : (pPlayer->EyePosition() + forward * MAX_TRACE_LENGTH);
+    QAngle vecAng = pPlayer->EyeAngles();
+
+    FOR_EACH_VEC( botVector, i )
+    {
+        botVector[i]->Teleport( &vecPos, &vecAng, NULL );
+    }
+}
 //------------------------------------------------------------------------------
 // Purpose: Force the specified bot to create & equip an item
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Added `bot_teleport_to_me` (name/index) to teleport a bot to your position
- For all bot commands, you can now use their player index instead of typing out their name
  - This allows you to make binds for "bot_teleport_to_me 3" for example, as there will always be a bot index 3. Before this, the bot names would change unless you specified them so a bind wouldn't work

Closes #262