### PR TITLE
Refactor nicknames with bugfixes for improved functionality

### DIFF
--- a/game/p4ss/resource/ui/hudmatchstatus.res
+++ b/game/p4ss/resource/ui/hudmatchstatus.res
@@ -408,11 +408,12 @@
 				"pinCorner"		"0"
 				"visible"		"1"
 				"visible_minmode" "1"
-				"labelText"		"%shortname%"
+				"labelText"		"%nickname%"
 				"textAlignment"	"center"
 				"fgcolor" 		"PFWhite" 
 				"proportionaltoparent"	"1"
 				"wrap" "0"
+				"allcaps"		"1"
 			}
 			"playernameBG"
 			{

--- a/game/p4ss/resource/ui/hudmatchstatus.res
+++ b/game/p4ss/resource/ui/hudmatchstatus.res
@@ -408,7 +408,7 @@
 				"pinCorner"		"0"
 				"visible"		"1"
 				"visible_minmode" "1"
-				"labelText"		"%nickname%"
+				"labelText"		"%shortname%"
 				"textAlignment"	"center"
 				"fgcolor" 		"PFWhite" 
 				"proportionaltoparent"	"1"

--- a/game/p4ss/resource/ui/hudpasstimeballstatus.res
+++ b/game/p4ss/resource/ui/hudpasstimeballstatus.res
@@ -432,6 +432,7 @@
 		"pin_to_sibling"	"ProgressBallIcon"
 		"pin_corner_to_sibling"		"4"
 		"pin_to_sibling_corner"		"4"
+		"allcaps"					"1"
 	}
 	
 

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -289,6 +289,8 @@ INetworkStringTable *g_pStringTableServerPopFiles = NULL;
 INetworkStringTable *g_pStringTableServerMapCycleMvM = NULL;
 #endif
 
+INetworkStringTable *g_pStringTableNicknames = NULL;
+
 static CGlobalVarsBase dummyvars( true );
 // So stuff that might reference gpGlobals during DLL initialization won't have a NULL pointer.
 // Once the engine calls Init on this DLL, this pointer gets assigned to the shared data in the engine
@@ -1800,6 +1802,8 @@ void CHLClient::ResetStringTablePointers()
 	g_pStringTableServerPopFiles = NULL;
 	g_pStringTableServerMapCycleMvM = NULL;
 #endif
+
+    g_pStringTableNicknames = NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -2051,6 +2055,10 @@ void CHLClient::InstallStringTableCallback( const char *tableName )
 		g_pStringTableServerMapCycleMvM = networkstringtable->FindTable( tableName );
 	}
 #endif
+	else if ( !Q_strcasecmp( tableName, "Nicknames" ) )
+	{
+		g_pStringTableNicknames = networkstringtable->FindTable( tableName );
+	}
 
 	InstallStringTableCallback_GameRules();
 }
@@ -2785,3 +2793,14 @@ CSteamID GetSteamIDForPlayerIndex( int iPlayerIndex )
 }
 
 #endif
+
+const wchar_t* GetClientNickname( int iClientIndex )
+{
+	auto value = static_cast<const wchar_t*>( g_pStringTableNicknames->GetStringUserData( iClientIndex - 1, NULL ) );
+	Assert( value );
+
+	if ( value && value[0] != 0 )
+	    return value;
+
+	return NULL;
+}

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -289,7 +289,7 @@ INetworkStringTable *g_pStringTableServerPopFiles = NULL;
 INetworkStringTable *g_pStringTableServerMapCycleMvM = NULL;
 #endif
 
-INetworkStringTable *g_pStringTableNicknames = NULL;
+INetworkStringTable *g_pStringTablePlayerShortNames = NULL;
 
 static CGlobalVarsBase dummyvars( true );
 // So stuff that might reference gpGlobals during DLL initialization won't have a NULL pointer.
@@ -1803,7 +1803,7 @@ void CHLClient::ResetStringTablePointers()
 	g_pStringTableServerMapCycleMvM = NULL;
 #endif
 
-    g_pStringTableNicknames = NULL;
+    g_pStringTablePlayerShortNames = NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -2055,9 +2055,9 @@ void CHLClient::InstallStringTableCallback( const char *tableName )
 		g_pStringTableServerMapCycleMvM = networkstringtable->FindTable( tableName );
 	}
 #endif
-	else if ( !Q_strcasecmp( tableName, "Nicknames" ) )
+	else if ( !Q_strcasecmp( tableName, "PlayerShortNames" ) )
 	{
-		g_pStringTableNicknames = networkstringtable->FindTable( tableName );
+		g_pStringTablePlayerShortNames = networkstringtable->FindTable( tableName );
 	}
 
 	InstallStringTableCallback_GameRules();
@@ -2794,13 +2794,11 @@ CSteamID GetSteamIDForPlayerIndex( int iPlayerIndex )
 
 #endif
 
-const wchar_t* GetClientNickname( int iClientIndex )
+const wchar_t* GetPlayerShortName( int iPlayerIndex )
 {
-	auto value = static_cast<const wchar_t*>( g_pStringTableNicknames->GetStringUserData( iClientIndex - 1, NULL ) );
-	Assert( value );
+	const wchar_t *value = static_cast<const wchar_t*>( g_pStringTablePlayerShortNames->GetStringUserData( iPlayerIndex - 1, NULL ) );
+	if ( !value || !value[0] )
+		return L"";
 
-	if ( value && value[0] != 0 )
-	    return value;
-
-	return NULL;
+	return value;
 }

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -2797,6 +2797,7 @@ CSteamID GetSteamIDForPlayerIndex( int iPlayerIndex )
 const wchar_t* GetPlayerShortName( int iPlayerIndex )
 {
 	const wchar_t *value = static_cast<const wchar_t*>( g_pStringTablePlayerShortNames->GetStringUserData( iPlayerIndex - 1, NULL ) );
+	Assert(value);
 	if ( !value || !value[0] )
 		return L"";
 

--- a/src/game/client/cdll_client_int.h
+++ b/src/game/client/cdll_client_int.h
@@ -171,6 +171,6 @@ extern CSteamID GetSteamIDForPlayerIndex( int iPlayerIndex );
 
 #endif
 
-const wchar_t* GetClientNickname( int iClientIndex );
+const wchar_t* GetPlayerShortName( int iPlayerIndex );
 
 #endif // CDLL_CLIENT_INT_H

--- a/src/game/client/cdll_client_int.h
+++ b/src/game/client/cdll_client_int.h
@@ -171,4 +171,6 @@ extern CSteamID GetSteamIDForPlayerIndex( int iPlayerIndex );
 
 #endif
 
+const wchar_t* GetClientNickname( int iClientIndex );
+
 #endif // CDLL_CLIENT_INT_H

--- a/src/game/client/networkstringtable_clientdll.h
+++ b/src/game/client/networkstringtable_clientdll.h
@@ -29,6 +29,6 @@ extern INetworkStringTable *g_pStringTableServerPopFiles;
 extern INetworkStringTable *g_pStringTableServerMapCycleMvM;
 #endif
 
-extern INetworkStringTable *g_pStringTableNicknames;
+extern INetworkStringTable *g_pStringTablePlayerShortNames;
 
 #endif // NETWORKSTRINGTABLE_CLIENTDLL_H

--- a/src/game/client/networkstringtable_clientdll.h
+++ b/src/game/client/networkstringtable_clientdll.h
@@ -29,4 +29,6 @@ extern INetworkStringTable *g_pStringTableServerPopFiles;
 extern INetworkStringTable *g_pStringTableServerMapCycleMvM;
 #endif
 
+extern INetworkStringTable *g_pStringTableNicknames;
+
 #endif // NETWORKSTRINGTABLE_CLIENTDLL_H

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -222,18 +222,6 @@ ConVar tf_romevision_skip_prompt( "tf_romevision_skip_prompt", "0", FCVAR_ARCHIV
 
 ConVar tf_chat_particle( "tf_chat_particle", "1", FCVAR_ARCHIVE, "Show typing bubble above player heads" );
 
-// p4ss short nick convar
-#define P4SS_MAXNICK = 5
-
-static void NickChange_Callback ( IConVar *var, const char *pOldValue, float flOldValue )
-{
-	char nick[5];
-	Q_strncpy( nick, ( (ConVar *)var )->GetString(), 5 );
-	var->SetValue( nick );
-}
-
-ConVar p4ss_nick( "p4ss_nick", "", FCVAR_ARCHIVE | FCVAR_USERINFO, "Short version of your nickname", NickChange_Callback );
-
 #define BDAY_HAT_MODEL		"models/effects/bday_hat.mdl"
 #define BOMB_HAT_MODEL		"models/props_lakeside_event/bomb_temp_hat.mdl"
 #define BOMBONOMICON_MODEL  "models/props_halloween/bombonomicon.mdl"
@@ -3773,8 +3761,6 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
 	RecvPropBool( RECVINFO( m_bReversedPasstimeGunControls ) ),
 	RecvPropBool( RECVINFO( m_bTyping ) ),
 
-	// p4ss: net recv
-	RecvPropString( RECVINFO( m_sPlayerShortNick ) ), 
 	END_RECV_TABLE()
 
 
@@ -11748,43 +11734,6 @@ void C_TFPlayer::ClientAdjustVOPitch( int& pitch )
 		}
 	}
 }
-
-
-bool C_TFPlayer::HasShortNick()
-{
-
-    if ( !g_PR || !g_PR->IsConnected( entindex() ) )
-        return false;
-    const char *pszShortName = m_sPlayerShortNick.Get();
-
-    return ( pszShortName && pszShortName[0] != '\0' );
-}
-
-//p4ss get
-const char *C_TFPlayer::GetShortNick()
-{
-    static char szCapNick[5];
-    const char *pszSourceName;
-
-    if ( HasShortNick() )
-        pszSourceName = m_sPlayerShortNick.Get();
-    else
-        pszSourceName = g_TF_PR->GetPlayerName( entindex() );
-
-    if ( !pszSourceName )
-        pszSourceName = ""; //null check
-
-    Q_strncpy( szCapNick, pszSourceName, sizeof( szCapNick ) );
-    
-    for ( int i = 0; i < sizeof( szCapNick ) - 1 && szCapNick[i] != '\0'; i++ )
-    {
-        szCapNick[i] = toupper( szCapNick[i] );
-    }
-    
-    return szCapNick;
-}
-
-
 
 //------------------------------------------------------------------------------
 // The serverbrowser has just added a server to the favorite list.

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -977,13 +977,6 @@ private:
 	float m_flTempForceDrawViewModelCycle  = 0.0f;
 
 	CNetworkVar( int, m_iPlayerSkinOverride );
-
-// p4ss additions
- public:
-	const char *GetShortNick();
-	bool HasShortNick();
-	CNetworkString( m_sPlayerShortNick, 5 );
-
 private:
 };
 

--- a/src/game/client/tf/tf_hud_flagstatus.cpp
+++ b/src/game/client/tf/tf_hud_flagstatus.cpp
@@ -370,6 +370,7 @@ CTFHudFlagObjectives::CTFHudFlagObjectives( Panel *parent, const char *name ) : 
 	m_pSpecCarriedImage = NULL;
 	m_pPoisonImage = NULL;
 	m_pPoisonTimeLabel = NULL;
+	m_pCapturePoint = NULL;
 
 	m_pRedFlag = new CTFFlagStatus( this, "RedFlag" );
 	m_pBlueFlag = new CTFFlagStatus( this, "BlueFlag" );

--- a/src/game/client/tf/tf_hud_passtime.cpp
+++ b/src/game/client/tf/tf_hud_passtime.cpp
@@ -1638,12 +1638,7 @@ void CTFHudPasstimeBallStatus::OnBallGet( int getterIndex )
 	if ( getterIndex > 0 )
 	{
 		pwszName = GetPlayerShortName( getterIndex );
-
-		if ( !pwszName )
-		{
-			pwszName = wszPlayerName;
-			g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( getterIndex ), wszPlayerName, sizeof( wszPlayerName ) );
-		}
+		g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( getterIndex ), wszPlayerName, sizeof( wszPlayerName ) );
 	}
 
 	g_pVGuiLocalize->ConstructString_safe( wszFinalText, pwszFormatString, 1, pwszName );

--- a/src/game/client/tf/tf_hud_passtime.cpp
+++ b/src/game/client/tf/tf_hud_passtime.cpp
@@ -1627,7 +1627,6 @@ void CTFHudPasstimeBallStatus::OnBallGet( int getterIndex )
 		return;
 
 	wchar_t wszFinalText[128];
-	wchar_t wszPlayerName[MAX_PLAYER_NAME_LENGTH];
 	wchar_t *pwszFormatString = g_pVGuiLocalize->Find( "#TF_Passtime_CarrierName" );
 	if ( !pwszFormatString )
 	{
@@ -1638,7 +1637,6 @@ void CTFHudPasstimeBallStatus::OnBallGet( int getterIndex )
 	if ( getterIndex > 0 )
 	{
 		pwszName = GetPlayerShortName( getterIndex );
-		g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( getterIndex ), wszPlayerName, sizeof( wszPlayerName ) );
 	}
 
 	g_pVGuiLocalize->ConstructString_safe( wszFinalText, pwszFormatString, 1, pwszName );

--- a/src/game/client/tf/tf_hud_passtime.cpp
+++ b/src/game/client/tf/tf_hud_passtime.cpp
@@ -1634,19 +1634,19 @@ void CTFHudPasstimeBallStatus::OnBallGet( int getterIndex )
 		pwszFormatString = L"%s1";
 	}
 
-	auto name = L"";
+	const wchar_t *pwszName = L"";
 	if ( getterIndex > 0 )
 	{
-		name = GetClientNickname( getterIndex );
+		pwszName = GetPlayerShortName( getterIndex );
 
-		if( !name )
+		if ( !pwszName )
 		{
-			name = wszPlayerName;
+			pwszName = wszPlayerName;
 			g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( getterIndex ), wszPlayerName, sizeof( wszPlayerName ) );
 		}
 	}
 
-	g_pVGuiLocalize->ConstructString_safe( wszFinalText, pwszFormatString, 1, name );
+	g_pVGuiLocalize->ConstructString_safe( wszFinalText, pwszFormatString, 1, pwszName );
 
 	m_pProgressBallCarrierName->SetText( wszFinalText );
 	m_pProgressBallCarrierName->SetVisible( true );

--- a/src/game/client/tf/tf_hud_passtime.cpp
+++ b/src/game/client/tf/tf_hud_passtime.cpp
@@ -1584,15 +1584,8 @@ bool CTFHudPasstimeBallStatus::TryForceBallGet()
 		{
 			continue;
 		}
-		
-		if ( g_TF_PR->IsLocalPlayer( iPlayer ) )
-		{
-			OnBallGetSelf( iPlayer );
-		}
-		else
-		{
-			OnBallGetOther( iPlayer );
-		}
+
+		OnBallGet( iPlayer );
 
 		return true;
 	}
@@ -1627,16 +1620,36 @@ bool CTFHudPasstimeBallStatus::TryForceBallFree()
 //-----------------------------------------------------------------------------
 void CTFHudPasstimeBallStatus::OnBallGet( int getterIndex )
 {
-	Assert( m_bInitialized && g_PR );
+	Assert( m_bInitialized );
+	Assert( g_PR );
 
-	if ( g_PR->IsLocalPlayer( getterIndex ) )
+	if ( !m_pProgressBallCarrierName )
+		return;
+
+	wchar_t wszFinalText[128];
+	wchar_t wszPlayerName[MAX_PLAYER_NAME_LENGTH];
+	wchar_t *pwszFormatString = g_pVGuiLocalize->Find( "#TF_Passtime_CarrierName" );
+	if ( !pwszFormatString )
 	{
-		OnBallGetSelf( getterIndex );
+		pwszFormatString = L"%s1";
 	}
-	else
+
+	auto name = L"";
+	if ( getterIndex > 0 )
 	{
-		OnBallGetOther( getterIndex );
+		name = GetClientNickname( getterIndex );
+
+		if( !name )
+		{
+			name = wszPlayerName;
+			g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( getterIndex ), wszPlayerName, sizeof( wszPlayerName ) );
+		}
 	}
+
+	g_pVGuiLocalize->ConstructString_safe( wszFinalText, pwszFormatString, 1, name );
+
+	m_pProgressBallCarrierName->SetText( wszFinalText );
+	m_pProgressBallCarrierName->SetVisible( true );
 }
 
 //-----------------------------------------------------------------------------
@@ -1776,52 +1789,6 @@ void CTFHudPasstimeBallStatus::OnBallFreeSelf( C_TFPlayer *pOwner,
 	if ( m_pProgressBallCarrierName )
 	{
 		m_pProgressBallCarrierName->SetVisible( false );
-	}
-}
-
-//-----------------------------------------------------------------------------
-void CTFHudPasstimeBallStatus::OnBallGetOther( int iPlayer )
-{
-	Assert( m_bInitialized );	
-	Assert( g_PR );
-
-	wchar_t wszFinalText[128];
-	wchar_t wszPlayerName[MAX_PLAYER_NAME_LENGTH];
-	wchar_t *pwszFormatString = g_pVGuiLocalize->Find( "#TF_Passtime_CarrierName" );
-	if ( !pwszFormatString )
-	{
-		pwszFormatString = L"%s1";
-	}
-	g_pVGuiLocalize->ConvertANSIToUnicode( ( iPlayer > 0 ) ? g_PR->GetPlayerName( iPlayer ) : "", wszPlayerName, sizeof( wszPlayerName ) );
-	g_pVGuiLocalize->ConstructString_safe( wszFinalText, pwszFormatString, 1, wszPlayerName );
-
-	if ( m_pProgressBallCarrierName )
-	{
-		m_pProgressBallCarrierName->SetText( wszFinalText );
-		m_pProgressBallCarrierName->SetVisible( true );
-	}
-}
-
-//-----------------------------------------------------------------------------
-void CTFHudPasstimeBallStatus::OnBallGetSelf( int iPlayer )
-{
-	Assert( m_bInitialized );	
-	Assert( g_PR );
-
-	wchar_t wszFinalText[128];
-	wchar_t wszPlayerName[MAX_PLAYER_NAME_LENGTH];
-	wchar_t *pwszFormatString = g_pVGuiLocalize->Find( "#TF_Passtime_CarrierName" );
-	if ( !pwszFormatString )
-	{
-		pwszFormatString = L"%s1";
-	}
-	g_pVGuiLocalize->ConvertANSIToUnicode( ( iPlayer > 0 ) ? g_PR->GetPlayerName( iPlayer ) : "", wszPlayerName, sizeof( wszPlayerName ) );
-	g_pVGuiLocalize->ConstructString_safe( wszFinalText, pwszFormatString, 1, wszPlayerName );
-
-	if ( m_pProgressBallCarrierName )
-	{
-		m_pProgressBallCarrierName->SetText( wszFinalText );
-		m_pProgressBallCarrierName->SetVisible( true );
 	}
 }
 

--- a/src/game/client/tf/tf_hud_passtime.h
+++ b/src/game/client/tf/tf_hud_passtime.h
@@ -175,8 +175,6 @@ private:
 
 	void OnBallFreeSelf( C_TFPlayer *pOwner, C_TFPlayer *pAttacker );
 	void OnBallFreeOther( C_TFPlayer *pOwner, C_TFPlayer *pAttacker );
-	void OnBallGetOther( int iPlayer );
-	void OnBallGetSelf( int iPlayer );
 	void OnBallScore();
 	bool TryForceBallFree();
 	bool TryForceBallGet();

--- a/src/game/client/tf/tf_hud_spectator_extras.cpp
+++ b/src/game/client/tf/tf_hud_spectator_extras.cpp
@@ -239,18 +239,10 @@ void CTFHudSpectatorExtras::OnTick()
 			// use actual name or disguised name?
 			int nNameIndex = pDisguiseTarget ? pDisguiseTarget->entindex() : i;
 
-			auto nickname = GetClientNickname( nNameIndex );
-			if ( nickname )
+			const wchar_t *pwszShortName = GetPlayerShortName( nNameIndex );
+			if ( pwszShortName )
 			{
-				V_wcsncpy( m_vecEntitiesToDraw[nVecIndex].m_wszName, nickname, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
-				auto nicknameLength = wcslen( m_vecEntitiesToDraw[nVecIndex].m_wszName );
-
-				for ( auto i = 0; i < nicknameLength; i++ )
-				{
-					auto upperChar = towupper(m_vecEntitiesToDraw[nVecIndex].m_wszName[i]);
-					if ( upperChar != WEOF )
-						m_vecEntitiesToDraw[nVecIndex].m_wszName[i] = upperChar;
-				}
+				V_wcsncpy( m_vecEntitiesToDraw[nVecIndex].m_wszName, pwszShortName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
 			}
 			else
 			{

--- a/src/game/client/tf/tf_hud_spectator_extras.cpp
+++ b/src/game/client/tf/tf_hud_spectator_extras.cpp
@@ -238,27 +238,25 @@ void CTFHudSpectatorExtras::OnTick()
 
 			// use actual name or disguised name?
 			int nNameIndex = pDisguiseTarget ? pDisguiseTarget->entindex() : i;
-			g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( nNameIndex ), m_vecEntitiesToDraw[nVecIndex].m_wszName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
 
-
-			if ( pDisguiseTarget )
+			auto nickname = GetClientNickname( nNameIndex );
+			if ( nickname )
 			{
-				int nNameIndex = pDisguiseTarget->entindex();
-				g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( nNameIndex ), m_vecEntitiesToDraw[nVecIndex].m_wszName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
+				V_wcsncpy( m_vecEntitiesToDraw[nVecIndex].m_wszName, nickname, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
+				auto nicknameLength = wcslen( m_vecEntitiesToDraw[nVecIndex].m_wszName );
+
+				for ( auto i = 0; i < nicknameLength; i++ )
+				{
+					auto upperChar = towupper(m_vecEntitiesToDraw[nVecIndex].m_wszName[i]);
+					if ( upperChar != WEOF )
+						m_vecEntitiesToDraw[nVecIndex].m_wszName[i] = upperChar;
+				}
 			}
 			else
 			{
-				C_TFPlayer *pTFPlayer = ToTFPlayer( pPlayer );
-				if ( pTFPlayer )
-				{
-					g_pVGuiLocalize->ConvertANSIToUnicode( pTFPlayer->GetShortNick(), m_vecEntitiesToDraw[nVecIndex].m_wszName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
-				}
-				else
-				{
-					// Fallback to regular name if cast fails
-					g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( i ), m_vecEntitiesToDraw[nVecIndex].m_wszName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
-				}
+				g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( nNameIndex ), m_vecEntitiesToDraw[nVecIndex].m_wszName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
 			}
+
 			m_vecEntitiesToDraw[nVecIndex].m_nNameWidth = UTIL_ComputeStringWidth( m_hNameFont, m_vecEntitiesToDraw[nVecIndex].m_wszName );
 
 			m_vecEntitiesToDraw[nVecIndex].m_nOffset = ( VEC_HULL_MAX_SCALED( pPlayer ).z );

--- a/src/game/client/tf/tf_hud_spectator_extras.cpp
+++ b/src/game/client/tf/tf_hud_spectator_extras.cpp
@@ -240,14 +240,7 @@ void CTFHudSpectatorExtras::OnTick()
 			int nNameIndex = pDisguiseTarget ? pDisguiseTarget->entindex() : i;
 
 			const wchar_t *pwszShortName = GetPlayerShortName( nNameIndex );
-			if ( pwszShortName )
-			{
-				V_wcsncpy( m_vecEntitiesToDraw[nVecIndex].m_wszName, pwszShortName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
-			}
-			else
-			{
-				g_pVGuiLocalize->ConvertANSIToUnicode( g_PR->GetPlayerName( nNameIndex ), m_vecEntitiesToDraw[nVecIndex].m_wszName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
-			}
+			V_wcsncpy( m_vecEntitiesToDraw[nVecIndex].m_wszName, pwszShortName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
 
 			m_vecEntitiesToDraw[nVecIndex].m_nNameWidth = UTIL_ComputeStringWidth( m_hNameFont, m_vecEntitiesToDraw[nVecIndex].m_wszName );
 

--- a/src/game/client/tf/tf_hud_spectator_extras.cpp
+++ b/src/game/client/tf/tf_hud_spectator_extras.cpp
@@ -240,7 +240,7 @@ void CTFHudSpectatorExtras::OnTick()
 			int nNameIndex = pDisguiseTarget ? pDisguiseTarget->entindex() : i;
 
 			const wchar_t *pwszShortName = GetPlayerShortName( nNameIndex );
-			V_wcsncpy( m_vecEntitiesToDraw[nVecIndex].m_wszName, pwszShortName, sizeof( m_vecEntitiesToDraw[nVecIndex].m_wszName ) );
+			V_wcscpy_safe( m_vecEntitiesToDraw[nVecIndex].m_wszName, pwszShortName );
 
 			m_vecEntitiesToDraw[nVecIndex].m_nNameWidth = UTIL_ComputeStringWidth( m_hNameFont, m_vecEntitiesToDraw[nVecIndex].m_wszName );
 

--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -1374,15 +1374,12 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 			{
 				iDominationIndex = ( bDominating ? ( m_iImageDomDead[iActiveDominations] ) : 0 );
 			}
-    		C_TFPlayer *pTFPlayer = ToTFPlayer( UTIL_PlayerByIndex( playerIndex ) );
 			KeyValues *pKeyValues = new KeyValues( "data" );
 			pKeyValues->SetInt( "playerIndex", playerIndex );
-			if ( pf_scoreboard_use_nicks.GetBool() )
+			auto nickname = GetClientNickname( playerIndex );
+			if ( pf_scoreboard_use_nicks.GetBool() && nickname )
 			{
-				if ( !pTFPlayer )
-					return;
-				const char *pszShortName = pTFPlayer->GetShortNick();
-				pKeyValues->SetString( "name", pszShortName );
+				pKeyValues->SetWString( "name", nickname );
 			}
 			else
 			{
@@ -1395,7 +1392,7 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 			pKeyValues->SetInt( "saves", g_TF_PR->GetP4ssSaves( playerIndex ) );
 			pKeyValues->SetInt( "connected", 2 );
 
-
+			C_TFPlayer *pTFPlayer = ToTFPlayer( UTIL_PlayerByIndex( playerIndex ) );
 			if ( pTFPlayer && pTFPlayer->GetActiveTFWeapon() )
 			{
 				int nCount = g_TF_PR->GetStreak( playerIndex, CTFPlayerShared::kTFStreak_Kills );
@@ -1859,12 +1856,13 @@ void CTFClientScoreBoardDialog::UpdatePlayerDetails()
 	if ( engine->IsHLTV() )
 #endif
 	{
-    	C_TFPlayer *pTFPlayer = ToTFPlayer( UTIL_PlayerByIndex( playerIndex ) );
-    	const char *pszPlayerName = g_TF_PR->GetPlayerName( playerIndex );
-		const char *pszShortName = pTFPlayer->GetShortNick();
+		const char *pszPlayerName = g_TF_PR->GetPlayerName( playerIndex );
+		auto nickname = GetClientNickname( playerIndex );
+		if ( !nickname )
+			nickname = L"";
 
-		SetDialogVariable( "shortname", pszShortName );
-    	SetDialogVariable( "playername", pszPlayerName );
+		SetDialogVariable( "playername", pszPlayerName );
+		SetDialogVariable( "nickname", nickname );
 		return;
 	}
 
@@ -1981,16 +1979,15 @@ void CTFClientScoreBoardDialog::UpdatePlayerDetails()
 		{
 			m_pDamageLabel->SetFgColor( g_TF_PR->GetDamage( playerIndex ) ? cGreen : cWhite );
 		}
-	}		
+	}
 
-	//SetDialogVariable( "playername", g_TF_PR->GetPlayerName( playerIndex ) );
-    	C_TFPlayer *pTFPlayer = ToTFPlayer( UTIL_PlayerByIndex( playerIndex ) );
-    	const char *pszPlayerName = g_TF_PR->GetPlayerName( playerIndex );
-		const char *pszShortName = pTFPlayer->GetShortNick();
+	const char *pszPlayerName = g_TF_PR->GetPlayerName( playerIndex );
+	auto nickname = GetClientNickname( playerIndex );
+	if ( !nickname )
+		nickname = L"";
 
-		SetDialogVariable( "shortname", pszShortName );
-    	SetDialogVariable( "playername", pszPlayerName );
-		return;
+	SetDialogVariable( "playername", pszPlayerName );
+	SetDialogVariable( "nickname", nickname );
 
 	Color clr = g_PR->GetTeamColor( g_PR->GetTeam( playerIndex ) );
 	m_pLabelPlayerName->SetFgColor( clr );

--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -79,7 +79,7 @@ void cc_scoreboard_convar_changed( IConVar *pConVar, const char *pOldString, flo
 ConVar tf_scoreboard_ping_as_text( "tf_scoreboard_ping_as_text", "0", FCVAR_ARCHIVE, "Show ping values as text in the scoreboard.", cc_scoreboard_convar_changed );
 ConVar tf_scoreboard_alt_class_icons( "tf_scoreboard_alt_class_icons", "0", FCVAR_ARCHIVE, "Show alternate class icons in the scoreboard." );
 
-ConVar pf_scoreboard_use_nicknames( "pf_scoreboard_use_nicknames", "0", FCVAR_ARCHIVE, "Use nicknames in place of player names in the scoreboard." );
+ConVar pf_scoreboard_use_shortnames( "pf_scoreboard_use_shortnames", "0", FCVAR_ARCHIVE, "Use shortnames in place of player names in the scoreboard." );
 
 extern bool IsInCommentaryMode( void );
 extern bool DuelMiniGame_GetStats( C_TFPlayer **ppPlayer, uint32 &unMyScore, uint32 &unOpponentScore );
@@ -1376,15 +1376,16 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 			}
 			KeyValues *pKeyValues = new KeyValues( "data" );
 			pKeyValues->SetInt( "playerIndex", playerIndex );
-			auto nickname = GetClientNickname( playerIndex );
-			if ( pf_scoreboard_use_nicknames.GetBool() && nickname )
+
+			if ( pf_scoreboard_use_shortnames.GetBool() )
 			{
-				pKeyValues->SetWString( "name", nickname );
+				pKeyValues->SetWString( "name", GetPlayerShortName( playerIndex ) );
 			}
 			else
 			{
 				pKeyValues->SetString( "name", g_TF_PR->GetPlayerName( playerIndex ) );
 			}
+
 			pKeyValues->SetInt( "dominating", iDominationIndex );
 			pKeyValues->SetInt( "goals", g_TF_PR->GetP4ssScores( playerIndex ) );
 			pKeyValues->SetInt( "assists", g_TF_PR->GetP4ssAssists( playerIndex ) );
@@ -1857,12 +1858,10 @@ void CTFClientScoreBoardDialog::UpdatePlayerDetails()
 #endif
 	{
 		const char *pszPlayerName = g_TF_PR->GetPlayerName( playerIndex );
-		auto nickname = GetClientNickname( playerIndex );
-		if ( !nickname )
-			nickname = L"";
+		const wchar_t *pwszShortName = GetPlayerShortName( playerIndex );
 
 		SetDialogVariable( "playername", pszPlayerName );
-		SetDialogVariable( "nickname", nickname );
+		SetDialogVariable( "shortname", pwszShortName );
 		return;
 	}
 
@@ -1982,12 +1981,10 @@ void CTFClientScoreBoardDialog::UpdatePlayerDetails()
 	}
 
 	const char *pszPlayerName = g_TF_PR->GetPlayerName( playerIndex );
-	auto nickname = GetClientNickname( playerIndex );
-	if ( !nickname )
-		nickname = L"";
+	const wchar_t *pwszShortName = GetPlayerShortName( playerIndex );
 
 	SetDialogVariable( "playername", pszPlayerName );
-	SetDialogVariable( "nickname", nickname );
+	SetDialogVariable( "shortname", pwszShortName );
 
 	Color clr = g_PR->GetTeamColor( g_PR->GetTeam( playerIndex ) );
 	m_pLabelPlayerName->SetFgColor( clr );

--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -79,7 +79,7 @@ void cc_scoreboard_convar_changed( IConVar *pConVar, const char *pOldString, flo
 ConVar tf_scoreboard_ping_as_text( "tf_scoreboard_ping_as_text", "0", FCVAR_ARCHIVE, "Show ping values as text in the scoreboard.", cc_scoreboard_convar_changed );
 ConVar tf_scoreboard_alt_class_icons( "tf_scoreboard_alt_class_icons", "0", FCVAR_ARCHIVE, "Show alternate class icons in the scoreboard." );
 
-ConVar pf_scoreboard_use_nicks( "pf_scoreboard_use_nicks", "0", FCVAR_ARCHIVE, "Use short nicknames in the scoreboard instead of full names." );
+ConVar pf_scoreboard_use_nicknames( "pf_scoreboard_use_nicknames", "0", FCVAR_ARCHIVE, "Use nicknames in place of player names in the scoreboard." );
 
 extern bool IsInCommentaryMode( void );
 extern bool DuelMiniGame_GetStats( C_TFPlayer **ppPlayer, uint32 &unMyScore, uint32 &unOpponentScore );
@@ -1377,7 +1377,7 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 			KeyValues *pKeyValues = new KeyValues( "data" );
 			pKeyValues->SetInt( "playerIndex", playerIndex );
 			auto nickname = GetClientNickname( playerIndex );
-			if ( pf_scoreboard_use_nicks.GetBool() && nickname )
+			if ( pf_scoreboard_use_nicknames.GetBool() && nickname )
 			{
 				pKeyValues->SetWString( "name", nickname );
 			}

--- a/src/game/client/tf/vgui/tf_playerpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playerpanel.cpp
@@ -54,18 +54,12 @@ CTFPlayerPanel::CTFPlayerPanel( vgui::Panel *parent, const char *name ) : vgui::
 	m_bPlayerReadyModeActive = false;
 	m_pReadyBG = new ScalableImagePanel( this , "ReadyBG" );
 	m_pReadyImage = new ImagePanel( this, "ReadyImage" );
-	m_pwszNickname = NULL;
 
 	SetDialogVariable( "chargeamount", "" );
 }
 
 CTFPlayerPanel::~CTFPlayerPanel()
 {
-    if( m_pwszNickname )
-    {
-        delete[] m_pwszNickname;
-        m_pwszNickname = NULL;
-    }
 }
 
 //-----------------------------------------------------------------------------
@@ -83,12 +77,6 @@ void CTFPlayerPanel::Reset( void )
 	m_iPrevState = GR_STATE_PREGAME;
 	m_bPlayerReadyModeActive = false;
 	m_nGCTeam = TEAM_INVALID;
-
-	if ( m_pwszNickname )
-	{
-		delete[] m_pwszNickname;
-		m_pwszNickname = NULL;
-	}
 }
 
 //-----------------------------------------------------------------------------
@@ -343,26 +331,25 @@ void CTFPlayerPanel::SetPlayerIndex( int iIndex )
 	}
 	else
 	{
-		Setup( iIndex, GetSteamIDForPlayerIndex( iIndex ), g_TF_PR->GetPlayerName( iIndex ), TEAM_INVALID, GetClientNickname( iIndex ) );
+		Setup( iIndex, GetSteamIDForPlayerIndex( iIndex ), g_TF_PR->GetPlayerName( iIndex ), TEAM_INVALID, GetPlayerShortName( iIndex ) );
 	}
 }
 
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CTFPlayerPanel::Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam /*= TEAM_INVALID*/, const wchar_t* pwszNickname /*=NULL*/ )
+void CTFPlayerPanel::Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam /*= TEAM_INVALID*/, const wchar_t* pwszShortName /*=NULL*/ )
 {
 	if ( pszPlayerName == NULL )
 		pszPlayerName = "";
-
-	auto nicknameChanged = ( m_pwszNickname && !pwszNickname )
-						|| ( !m_pwszNickname && pwszNickname )
-						|| ( m_pwszNickname && pwszNickname && V_wcscmp( m_pwszNickname, pwszNickname ) );
+	
+	if ( pwszShortName == NULL )
+		pwszShortName = L"";
 
 	if ( m_iPlayerIndex != iPlayerIndex
 		|| m_steamID != steamID
-		|| Q_strcmp( m_sPlayerName, pszPlayerName )
-		|| nicknameChanged )
+		|| m_sPlayerName != pszPlayerName
+		|| m_wszPlayerShortName != pwszShortName )
 	{
 		Reset();
 		m_iPlayerIndex = iPlayerIndex;
@@ -370,17 +357,8 @@ void CTFPlayerPanel::Setup( int iPlayerIndex, CSteamID steamID, const char *pszP
 		m_sPlayerName = pszPlayerName;
 		SetDialogVariable( "playername", m_sPlayerName );
 
-		if ( nicknameChanged && pwszNickname )
-		{
-			auto length = wcslen( pwszNickname ) + 1;
-			m_pwszNickname = new wchar_t[length];
-			V_wcsncpy( m_pwszNickname, pwszNickname, length * sizeof( wchar_t ) );
-		}
-
-		if ( m_pwszNickname )
-			SetDialogVariable( "nickname", m_pwszNickname );
-		else
-			SetDialogVariable( "nickname", "" );
+		m_wszPlayerShortName = pwszShortName;
+		SetDialogVariable( "shortname", m_wszPlayerShortName );
 
 		m_nGCTeam = nLobbyTeam;
 	}

--- a/src/game/client/tf/vgui/tf_playerpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playerpanel.cpp
@@ -58,10 +58,6 @@ CTFPlayerPanel::CTFPlayerPanel( vgui::Panel *parent, const char *name ) : vgui::
 	SetDialogVariable( "chargeamount", "" );
 }
 
-CTFPlayerPanel::~CTFPlayerPanel()
-{
-}
-
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -342,7 +338,7 @@ void CTFPlayerPanel::Setup( int iPlayerIndex, CSteamID steamID, const char *pszP
 {
 	if ( pszPlayerName == NULL )
 		pszPlayerName = "";
-	
+
 	if ( pwszShortName == NULL )
 		pwszShortName = L"";
 

--- a/src/game/client/tf/vgui/tf_playerpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playerpanel.cpp
@@ -54,8 +54,18 @@ CTFPlayerPanel::CTFPlayerPanel( vgui::Panel *parent, const char *name ) : vgui::
 	m_bPlayerReadyModeActive = false;
 	m_pReadyBG = new ScalableImagePanel( this , "ReadyBG" );
 	m_pReadyImage = new ImagePanel( this, "ReadyImage" );
+	m_pwszNickname = NULL;
 
 	SetDialogVariable( "chargeamount", "" );
+}
+
+CTFPlayerPanel::~CTFPlayerPanel()
+{
+    if( m_pwszNickname )
+    {
+        delete[] m_pwszNickname;
+        m_pwszNickname = NULL;
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -73,6 +83,12 @@ void CTFPlayerPanel::Reset( void )
 	m_iPrevState = GR_STATE_PREGAME;
 	m_bPlayerReadyModeActive = false;
 	m_nGCTeam = TEAM_INVALID;
+
+	if ( m_pwszNickname )
+	{
+		delete[] m_pwszNickname;
+		m_pwszNickname = NULL;
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -327,34 +343,45 @@ void CTFPlayerPanel::SetPlayerIndex( int iIndex )
 	}
 	else
 	{
-		Setup( iIndex, GetSteamIDForPlayerIndex( iIndex ), g_TF_PR->GetPlayerName( iIndex ) );
+		Setup( iIndex, GetSteamIDForPlayerIndex( iIndex ), g_TF_PR->GetPlayerName( iIndex ), TEAM_INVALID, GetClientNickname( iIndex ) );
 	}
 }
 
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CTFPlayerPanel::Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam /*= TEAM_INVALID*/ )
+void CTFPlayerPanel::Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam /*= TEAM_INVALID*/, const wchar_t* pwszNickname /*=NULL*/ )
 {
 	if ( pszPlayerName == NULL )
 		pszPlayerName = "";
+
+	auto nicknameChanged = ( m_pwszNickname && !pwszNickname )
+						|| ( !m_pwszNickname && pwszNickname )
+						|| ( m_pwszNickname && pwszNickname && V_wcscmp( m_pwszNickname, pwszNickname ) );
+
 	if ( m_iPlayerIndex != iPlayerIndex
 		|| m_steamID != steamID
-		|| Q_strcmp( m_sPlayerName, pszPlayerName ) )
+		|| Q_strcmp( m_sPlayerName, pszPlayerName )
+		|| nicknameChanged )
 	{
 		Reset();
 		m_iPlayerIndex = iPlayerIndex;
 		m_steamID = steamID;
 		m_sPlayerName = pszPlayerName;
-    	C_TFPlayer *pTFPlayer = ToTFPlayer( UTIL_PlayerByIndex( iPlayerIndex ) );
-		const char *pszShortName = "";
-		if ( pTFPlayer && g_PR && g_PR->IsConnected( iPlayerIndex ) )
+		SetDialogVariable( "playername", m_sPlayerName );
+
+		if ( nicknameChanged && pwszNickname )
 		{
-			pszShortName = pTFPlayer->GetShortNick();
+			auto length = wcslen( pwszNickname ) + 1;
+			m_pwszNickname = new wchar_t[length];
+			V_wcsncpy( m_pwszNickname, pwszNickname, length * sizeof( wchar_t ) );
 		}
 
-		SetDialogVariable( "shortname", pszShortName );
-		SetDialogVariable( "playername", m_sPlayerName );
+		if ( m_pwszNickname )
+			SetDialogVariable( "nickname", m_pwszNickname );
+		else
+			SetDialogVariable( "nickname", "" );
+
 		m_nGCTeam = nLobbyTeam;
 	}
 

--- a/src/game/client/tf/vgui/tf_playerpanel.h
+++ b/src/game/client/tf/vgui/tf_playerpanel.h
@@ -44,7 +44,7 @@ public:
 	virtual bool	Update( void );
 	void	SetPlayerIndex( int iIndex );
 	int		GetPlayerIndex( void ) { return m_iPlayerIndex; }
-	void	Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam = TEAM_INVALID, const wchar_t* pwszNickname = NULL );
+	void	Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam = TEAM_INVALID, const wchar_t* pwszShortName = L"" );
 	void	SetSpecIndex( int iIndex );
 	int		GetSpecIndex( void ) { return m_iSpecIndex; }
 	virtual void	UpdateBorder( void );
@@ -72,7 +72,7 @@ protected:
 	int						m_iPrevState;
 	bool					m_bPlayerReadyModeActive;
 	int						m_nGCTeam;
-	wchar_t					*m_pwszNickname;
+	CUtlConstWideString		m_wszPlayerShortName;
 };
 
 

--- a/src/game/client/tf/vgui/tf_playerpanel.h
+++ b/src/game/client/tf/vgui/tf_playerpanel.h
@@ -36,6 +36,7 @@ class CTFPlayerPanel : public vgui::EditablePanel
 	DECLARE_CLASS_SIMPLE( CTFPlayerPanel, vgui::EditablePanel );
 public:
 	CTFPlayerPanel( vgui::Panel *parent, const char *name );
+	virtual ~CTFPlayerPanel();
 
 	virtual void	Reset( void );
 	virtual void	ApplySchemeSettings( vgui::IScheme *pScheme );
@@ -43,7 +44,7 @@ public:
 	virtual bool	Update( void );
 	void	SetPlayerIndex( int iIndex );
 	int		GetPlayerIndex( void ) { return m_iPlayerIndex; }
-	void	Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam = TEAM_INVALID );
+	void	Setup( int iPlayerIndex, CSteamID steamID, const char *pszPlayerName, int nLobbyTeam = TEAM_INVALID, const wchar_t* pwszNickname = NULL );
 	void	SetSpecIndex( int iIndex );
 	int		GetSpecIndex( void ) { return m_iSpecIndex; }
 	virtual void	UpdateBorder( void );
@@ -71,6 +72,7 @@ protected:
 	int						m_iPrevState;
 	bool					m_bPlayerReadyModeActive;
 	int						m_nGCTeam;
+	wchar_t					*m_pwszNickname;
 };
 
 

--- a/src/game/client/tf/vgui/tf_playerpanel.h
+++ b/src/game/client/tf/vgui/tf_playerpanel.h
@@ -36,7 +36,7 @@ class CTFPlayerPanel : public vgui::EditablePanel
 	DECLARE_CLASS_SIMPLE( CTFPlayerPanel, vgui::EditablePanel );
 public:
 	CTFPlayerPanel( vgui::Panel *parent, const char *name );
-	virtual ~CTFPlayerPanel();
+	virtual ~CTFPlayerPanel() = default;
 
 	virtual void	Reset( void );
 	virtual void	ApplySchemeSettings( vgui::IScheme *pScheme );

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -226,6 +226,8 @@ INetworkStringTable *g_pStringTableServerPopFiles = NULL;
 INetworkStringTable *g_pStringTableServerMapCycleMvM = NULL;
 #endif
 
+INetworkStringTable *g_pStringTableNicknames = NULL;
+
 CStringTableSaveRestoreOps g_VguiScreenStringOps;
 
 // Holds global variables shared between engine and game.
@@ -1453,6 +1455,8 @@ void CServerGameDLL::CreateNetworkStringTables( void )
 	g_pStringTableServerMapCycleMvM = networkstringtable->CreateStringTable( "ServerMapCycleMvM", 128 );
 #endif
 
+	g_pStringTableNicknames = networkstringtable->CreateStringTable( "Nicknames", 1 << ABSOLUTE_PLAYER_LIMIT_DW );
+
 	bool bPopFilesValid = true;
 	(void)bPopFilesValid; // Avoid unreferenced variable warning
 
@@ -1466,7 +1470,8 @@ void CServerGameDLL::CreateNetworkStringTables( void )
 			g_pStringTableMaterials &&
 			g_pStringTableInfoPanel &&
 			g_pStringTableClientSideChoreoScenes &&
-			g_pStringTableServerMapCycle && 
+			g_pStringTableServerMapCycle &&
+			g_pStringTableNicknames &&
 			bPopFilesValid
 			);
 
@@ -1481,6 +1486,13 @@ void CServerGameDLL::CreateNetworkStringTables( void )
 
 	// Set up save/load utilities for string tables
 	g_VguiScreenStringOps.Init( g_pStringTableVguiScreen );
+
+	char name[8];
+	for ( auto i = 0; i < gpGlobals->maxClients; i++ )
+	{
+		Q_snprintf( name, 8, "%i", i );
+		Assert( i == g_pStringTableNicknames->AddString( true, name ) ); // matching indices
+	}
 }
 
 CSaveRestoreData *CServerGameDLL::SaveInit( int size )

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -226,7 +226,7 @@ INetworkStringTable *g_pStringTableServerPopFiles = NULL;
 INetworkStringTable *g_pStringTableServerMapCycleMvM = NULL;
 #endif
 
-INetworkStringTable *g_pStringTableNicknames = NULL;
+INetworkStringTable *g_pStringTablePlayerShortNames = NULL;
 
 CStringTableSaveRestoreOps g_VguiScreenStringOps;
 
@@ -1455,7 +1455,7 @@ void CServerGameDLL::CreateNetworkStringTables( void )
 	g_pStringTableServerMapCycleMvM = networkstringtable->CreateStringTable( "ServerMapCycleMvM", 128 );
 #endif
 
-	g_pStringTableNicknames = networkstringtable->CreateStringTable( "Nicknames", 1 << ABSOLUTE_PLAYER_LIMIT_DW );
+	g_pStringTablePlayerShortNames = networkstringtable->CreateStringTable( "PlayerShortNames", 1 << ABSOLUTE_PLAYER_LIMIT_DW );
 
 	bool bPopFilesValid = true;
 	(void)bPopFilesValid; // Avoid unreferenced variable warning
@@ -1471,7 +1471,7 @@ void CServerGameDLL::CreateNetworkStringTables( void )
 			g_pStringTableInfoPanel &&
 			g_pStringTableClientSideChoreoScenes &&
 			g_pStringTableServerMapCycle &&
-			g_pStringTableNicknames &&
+			g_pStringTablePlayerShortNames &&
 			bPopFilesValid
 			);
 
@@ -1487,11 +1487,9 @@ void CServerGameDLL::CreateNetworkStringTables( void )
 	// Set up save/load utilities for string tables
 	g_VguiScreenStringOps.Init( g_pStringTableVguiScreen );
 
-	char name[8];
-	for ( auto i = 0; i < gpGlobals->maxClients; i++ )
+	for ( int i = 0; i < gpGlobals->maxClients; i++ )
 	{
-		Q_snprintf( name, 8, "%i", i );
-		Assert( i == g_pStringTableNicknames->AddString( true, name ) ); // matching indices
+		g_pStringTablePlayerShortNames->AddString( true, CNumStr( i ) ); // matching indices
 	}
 }
 

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -846,9 +846,6 @@ IMPLEMENT_SERVERCLASS_ST( CTFPlayer, DT_TFPlayer )
 	SendPropBool( SENDINFO( m_bLegacyPasstimeGunControls ) ),
 	SendPropBool( SENDINFO( m_bReversedPasstimeGunControls ) ),
 	SendPropBool( SENDINFO( m_bTyping ) ),
-
-	// p4ss: net send props
-	SendPropString( SENDINFO(m_sPlayerShortNick) ),
 END_SEND_TABLE()
 
 // -------------------------------------------------------------------------------- //

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -1559,14 +1559,6 @@ public:
 
 	virtual bool BCanCallVote() OVERRIDE;
 	bool m_bFirstSpawnAndCanCallVote = false;
-
-
-public:
-	const char *GetShortNick();
-
-	CNetworkString( m_sPlayerShortNick, 5 );
-private:
-
 };
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/multiplay_gamerules.h
+++ b/src/game/shared/multiplay_gamerules.h
@@ -34,7 +34,7 @@ extern INetworkStringTable *g_pStringTableServerPopFiles;
 extern INetworkStringTable *g_pStringTableServerMapCycleMvM;
 #endif
 
-extern INetworkStringTable *g_pStringTableNicknames;
+extern INetworkStringTable *g_pStringTablePlayerShortNames;
 
 #define VOICE_COMMAND_MAX_SUBTITLE_DIST	1900
 

--- a/src/game/shared/multiplay_gamerules.h
+++ b/src/game/shared/multiplay_gamerules.h
@@ -34,6 +34,8 @@ extern INetworkStringTable *g_pStringTableServerPopFiles;
 extern INetworkStringTable *g_pStringTableServerMapCycleMvM;
 #endif
 
+extern INetworkStringTable *g_pStringTableNicknames;
+
 #define VOICE_COMMAND_MAX_SUBTITLE_DIST	1900
 
 class CBaseMultiplayerPlayer;

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -10206,18 +10206,17 @@ void CTFGameRules::ChangePlayerName( CTFPlayer *pPlayer, const char *pszNewName 
 	pPlayer->SetPlayerName( pszNewName );
 }
 
-void SetupPlayerShortName( wchar_t *buffer, int length )
+template <size_t len>
+void SetupPlayerShortName( wchar_t ( &buffer )[len] )
 {
-	if ( !buffer || length <= 0 )
-		return;
-
 	// Trim trailing space
-	while ( length > 0 && iswspace( buffer[length - 1] ) )
+	size_t length = len;
+	while ( length > 0  && ( buffer[length - 1] == L'\0' || iswspace( buffer[length - 1] ) ) )
 		buffer[ --length ] = L'\0';
 
 	// Trim leading space
 	int skip = 0;
-	while ( skip < length && iswspace( buffer[skip] ) )
+	while ( skip < len && iswspace( buffer[skip] ) )
 		++skip;
 
 	if ( skip > 0 )
@@ -10229,8 +10228,8 @@ void SetupPlayerShortName( wchar_t *buffer, int length )
 	}
 
 	// Convert to Uppercase
-    for ( ; *buffer; ++buffer )
-		*buffer = towupper( *buffer );
+	for ( wchar_t *p = buffer; *p; ++p )
+		*p = towupper( *p );
 }
 
 //-----------------------------------------------------------------------------
@@ -10285,8 +10284,8 @@ void CTFGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 
 	wchar_t wszPlayerShortname[P4SS_SHORTNAME_MAX_CHARS + 1] = { 0 };
 	g_pVGuiLocalize->ConvertANSIToUnicode( pszPlayerShortName, wszPlayerShortname, sizeof( wszPlayerShortname ) );
-	SetupPlayerShortName( wszPlayerShortname, sizeof( wszPlayerShortname ) );
-
+	SetupPlayerShortName( wszPlayerShortname );
+	
 	g_pStringTablePlayerShortNames->SetStringUserData( pPlayer->entindex() - 1, sizeof( wszPlayerShortname), wszPlayerShortname );
 }
 

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -13362,6 +13362,8 @@ void CTFGameRules::ClientDisconnected( edict_t *pClient )
 			}
 		}
 	}
+
+	g_pStringTablePlayerShortNames->SetStringUserData( engine->IndexOfEdict( pClient ) - 1, 0, NULL );
 }
 
 // Falling damage stuff.

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -884,6 +884,8 @@ ConVar tf_mvm_respec_credit_goal( "tf_mvm_respec_credit_goal", "2000", FCVAR_CHE
 ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED | FCVAR_HIDDEN, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
 ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED | FCVAR_HIDDEN, "The fixed number of buybacks players can use per-wave." );
 
+#define P4SS_NICKNAME_MAX_CHARS 4
+ConVar pf_nickname( "pf_nickname", "", FCVAR_ARCHIVE | FCVAR_USERINFO, "Shortened user name" );
 
 #ifdef GAME_DLL
 enum { kMVM_CurrencyPackMinSize = 1, };
@@ -10204,6 +10206,40 @@ void CTFGameRules::ChangePlayerName( CTFPlayer *pPlayer, const char *pszNewName 
 	pPlayer->SetPlayerName( pszNewName );
 }
 
+wchar_t* TrimNickname( wchar_t* buffer, int* length )
+{
+	// Trim leading space
+	for ( auto i = 0; i < *length - 2; i++ )
+	{
+		if ( buffer[i] == L' ' )
+		{
+			buffer++;
+			--(*length);
+			--i;
+		}
+		else
+		{
+			break;
+		}
+	}
+
+	// Trim trailing space
+	for ( auto i = *length - 2; i >= 0; --i )
+	{
+		if ( buffer[i] == L' ' )
+		{
+			buffer[i] = 0;
+			--(*length);
+		}
+		else
+		{
+			break;
+		}
+	}
+
+	return buffer;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -10250,10 +10286,12 @@ void CTFGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	pTFPlayer->SetUseLegacyPasstimeGunControls( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "pf_legacy_throw_controls" ) ) > 0 );
 	pTFPlayer->SetUseReversedPasstimeGunControls( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "pf_reverse_throw_controls" ) ) > 0);
 
-	// p4ss short nickname
-	const char *newNick = engine->GetClientConVarValue( pPlayer->entindex(), "p4ss_nick" );
-	Q_strncpy( pTFPlayer->m_sPlayerShortNick.GetForModify(), newNick, 5 );
+	wchar_t nicknameBuffer[P4SS_NICKNAME_MAX_CHARS + 1];
 
+	auto nicknameLength = g_pVGuiLocalize->ConvertANSIToUnicode( engine->GetClientConVarValue( pPlayer->entindex(), "pf_nickname" ), nicknameBuffer, sizeof( nicknameBuffer ) );
+	auto nickname = TrimNickname( nicknameBuffer, &nicknameLength );
+
+	g_pStringTableNicknames->SetStringUserData( pPlayer->entindex() - 1, nicknameLength * sizeof( wchar_t ), nickname );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -884,8 +884,8 @@ ConVar tf_mvm_respec_credit_goal( "tf_mvm_respec_credit_goal", "2000", FCVAR_CHE
 ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED | FCVAR_HIDDEN, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
 ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED | FCVAR_HIDDEN, "The fixed number of buybacks players can use per-wave." );
 
-#define P4SS_NICKNAME_MAX_CHARS 4
-ConVar pf_nickname( "pf_nickname", "", FCVAR_ARCHIVE | FCVAR_USERINFO, "Shortened user name" );
+#define P4SS_SHORTNAME_MAX_CHARS 4
+ConVar pf_shortname( "pf_shortname", "", FCVAR_ARCHIVE | FCVAR_USERINFO, "Shortened user name" );
 
 #ifdef GAME_DLL
 enum { kMVM_CurrencyPackMinSize = 1, };
@@ -10206,38 +10206,31 @@ void CTFGameRules::ChangePlayerName( CTFPlayer *pPlayer, const char *pszNewName 
 	pPlayer->SetPlayerName( pszNewName );
 }
 
-wchar_t* TrimNickname( wchar_t* buffer, int* length )
+void SetupPlayerShortName( wchar_t *buffer, int length )
 {
-	// Trim leading space
-	for ( auto i = 0; i < *length - 2; i++ )
-	{
-		if ( buffer[i] == L' ' )
-		{
-			buffer++;
-			--(*length);
-			--i;
-		}
-		else
-		{
-			break;
-		}
-	}
+	if ( !buffer || length <= 0 )
+		return;
 
 	// Trim trailing space
-	for ( auto i = *length - 2; i >= 0; --i )
+	while ( length > 0 && iswspace( buffer[length - 1] ) )
+		buffer[ --length ] = L'\0';
+
+	// Trim leading space
+	int skip = 0;
+	while ( skip < length && iswspace( buffer[skip] ) )
+		++skip;
+
+	if ( skip > 0 )
 	{
-		if ( buffer[i] == L' ' )
-		{
-			buffer[i] = 0;
-			--(*length);
-		}
-		else
-		{
-			break;
-		}
+		wchar_t *pDst = buffer;
+		wchar_t *pSrc = buffer + skip;
+
+		while ( ( *pDst++ = *pSrc++ ) != L'\0' );
 	}
 
-	return buffer;
+	// Convert to Uppercase
+    for ( ; *buffer; ++buffer )
+		*buffer = towupper( *buffer );
 }
 
 //-----------------------------------------------------------------------------
@@ -10286,12 +10279,15 @@ void CTFGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	pTFPlayer->SetUseLegacyPasstimeGunControls( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "pf_legacy_throw_controls" ) ) > 0 );
 	pTFPlayer->SetUseReversedPasstimeGunControls( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "pf_reverse_throw_controls" ) ) > 0);
 
-	wchar_t nicknameBuffer[P4SS_NICKNAME_MAX_CHARS + 1];
+	const char *pszPlayerShortName = engine->GetClientConVarValue( pPlayer->entindex(), "pf_shortname" );
+	if ( !pszPlayerShortName || !pszPlayerShortName[0] )
+		pszPlayerShortName = pPlayer->GetPlayerName();
 
-	auto nicknameLength = g_pVGuiLocalize->ConvertANSIToUnicode( engine->GetClientConVarValue( pPlayer->entindex(), "pf_nickname" ), nicknameBuffer, sizeof( nicknameBuffer ) );
-	auto nickname = TrimNickname( nicknameBuffer, &nicknameLength );
+	wchar_t wszPlayerShortname[P4SS_SHORTNAME_MAX_CHARS + 1] = { 0 };
+	g_pVGuiLocalize->ConvertANSIToUnicode( pszPlayerShortName, wszPlayerShortname, sizeof( wszPlayerShortname ) );
+	SetupPlayerShortName( wszPlayerShortname, sizeof( wszPlayerShortname ) );
 
-	g_pStringTableNicknames->SetStringUserData( pPlayer->entindex() - 1, nicknameLength * sizeof( wchar_t ), nickname );
+	g_pStringTablePlayerShortNames->SetStringUserData( pPlayer->entindex() - 1, sizeof( wszPlayerShortname), wszPlayerShortname );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -10216,7 +10216,7 @@ void SetupPlayerShortName( wchar_t ( &buffer )[len] )
 
 	// Trim leading space
 	int skip = 0;
-	while ( skip < len && iswspace( buffer[skip] ) )
+	while ( skip < length && iswspace( buffer[skip] ) )
 		++skip;
 
 	if ( skip > 0 )


### PR DESCRIPTION
The existing implementation and usage of nicknames had some flaws, so the following changes remedy this:
- Use a string table to network nicknames
  - Fixes PVS issues caused by networking over the player entity (nicknames not updating).
- Correct implementation for player panels
  - Fixes nicknames not updating.
- Correct implementation for scoreboard
  - Fixes copy-paste bug preventing scoreboard from adding certain players entirely.
- Trim nicknames
- Remove all references to "shortname", replacing it with "nickname"
  - Call it by one name, not both.