### PR TITLE
Jack minicrit rework & health on pass addition

### DIFF
--- a/src/game/server/tf/tf_passtime_ball.cpp
+++ b/src/game/server/tf/tf_passtime_ball.cpp
@@ -698,14 +698,19 @@ void CPasstimeBall::SetStateCarried( CTFPlayer *pCarrier )
 	pCarrier->m_Shared.SetHasPasstimeBall( true );
 	if ( pCarrier != m_hPrevCarrier )
 	{
+		float fPassTimeLength = gpGlobals->realtime - g_pPasstimeLogic->GetLastPassTime(pCarrier);
 		pCarrier->m_Shared.AddCond( TF_COND_SPEED_BOOST, tf_passtime_speedboost_on_get_ball_time.GetFloat() );
 
 		// Limit points by time so we can't just throw back and forth a ton for points.
 		// FIXME awarding points here and also in passtime_logic?
-		if ( gpGlobals->realtime - g_pPasstimeLogic->GetLastPassTime(pCarrier) > 6.0f ) // FIXME literal balance value
+		if ( fPassTimeLength > p4ss_heal_on_pass_flight_time.GetFloat() ) // FIXME literal balance value
 		{
-			CTF_GameStats.Event_PlayerAwardBonusPoints(pCarrier, 0, 5); // FIXME literal balance value
-			g_pPasstimeLogic->SetLastPassTime(pCarrier);
+			pCarrier->SetHealth(pCarrier->GetHealth() + p4ss_heal_on_pass.GetFloat());
+			if ( fPassTimeLength > 6.0f ) // FIXME literal balance value
+			{
+				CTF_GameStats.Event_PlayerAwardBonusPoints(pCarrier, 0, 5 ); // FIXME literal balance value
+				g_pPasstimeLogic->SetLastPassTime( pCarrier );
+			}
 		}
 	}
 	pCarrier->TeamFortress_SetSpeed();

--- a/src/game/server/tf/tf_passtime_logic.cpp
+++ b/src/game/server/tf/tf_passtime_logic.cpp
@@ -454,11 +454,11 @@ void CTFPasstimeLogic::BallPower_PackThink()
 	m_flPackSpeed = 0.0f;
 	m_nPrevPackMemberBits = m_nPackMemberBits;
 	m_nPackMemberBits = 0;
-
+	
 	CTFPlayer *pCarrier = GetBallCarrier();
 
 	// Check if pack speed is active
-	if ( !tf_passtime_pack_speed.GetBool() || !IsGamestatePlayable() || !pCarrier )
+	if ( tf_passtime_pack_range.GetFloat() <= 0 || !IsGamestatePlayable() || !pCarrier )
 	{
 		m_nPackMemberBits = 0; // redundant assignment for clarity
 		ReplicatePackMemberBits();
@@ -487,8 +487,19 @@ void CTFPasstimeLogic::BallPower_PackThink()
 		}
 	}
 
-	// Apply marked for death if no teammates
-	if ( !bHasNearbyTeammate )
+	// Mini-crit conditions
+	if ( m_flBallLastReceived + p4ss_minicrit_protection_time.GetFloat() < gpGlobals->curtime || 
+		( pCarrier->InAirDueToExplosion() && ( m_flBallLastReceived + 0.15f < gpGlobals->curtime ) ) )
+	{
+		m_bProtActive = false;
+		pCarrier->m_Shared.AddCond( TF_COND_PASSTIME_PENALTY_DEBUFF, TICK_INTERVAL * 2 );
+	}
+	else if (bHasNearbyTeammate)
+	{
+		m_bProtActive = true;
+		m_flPackSpeed = flMaxMaxSpeed;
+	}
+	else if (!bHasNearbyTeammate && !m_bProtActive)
 	{
 		pCarrier->m_Shared.AddCond( TF_COND_PASSTIME_PENALTY_DEBUFF, TICK_INTERVAL * 2 );
 	}
@@ -505,6 +516,7 @@ void CTFPasstimeLogic::BallPower_PackThink()
 void CTFPasstimeLogic::BallPower_PackHealThink()
 {
 	SetContextThink( &CTFPasstimeLogic::BallPower_PackHealThink, gpGlobals->curtime + 1, "packheal" );
+	if (tf_passtime_pack_hp_per_sec.GetFloat() <= 0) return;
 
 	CTFPlayer *pCarrier = GetBallCarrier();
 	if ( !pCarrier )
@@ -548,6 +560,7 @@ void CTFPasstimeLogic::BallPower_PackHealThink()
 //-----------------------------------------------------------------------------
 float CTFPasstimeLogic::GetPackSpeed( CTFPlayer *pPlayer ) const
 {
+	if (tf_passtime_pack_speed.GetFloat() <= 0) return 0;
 	if ( pPlayer )
 	{
 		uint64 nMask = (uint64)1 << ( pPlayer->entindex() - 1 );
@@ -1868,6 +1881,11 @@ void CTFPasstimeLogic::OnBallGet()
 	}
 	if ( CTFPlayer *pPlayer = m_hBall->GetCarrier() )
 	{
+		if (m_hBall->GetPrevCarrier() != pPlayer)
+		{
+			m_flBallLastReceived = gpGlobals->curtime;
+			m_bProtActive = false;
+		}
 		m_onBallGetAny.FireOutput( pPlayer, this );
 		if ( pPlayer->GetTeamNumber() == TF_TEAM_RED )
 		{

--- a/src/game/server/tf/tf_passtime_logic.h
+++ b/src/game/server/tf/tf_passtime_logic.h
@@ -108,6 +108,8 @@ private:
 	float m_flNextCrowdReactionTime;
 	uint64 m_nPackMemberBits;
 	uint64 m_nPrevPackMemberBits;
+	float m_flBallLastReceived;
+	bool m_bProtActive;
 
 	// outputs
 	COutputEvent m_onBallFree;

--- a/src/game/shared/tf/passtime_convars.cpp
+++ b/src/game/shared/tf/passtime_convars.cpp
@@ -84,3 +84,6 @@ PASSTIME_CONVAR( p4ss_med_canpushball, 1, "Enables med pushing ball with crossbo
 PASSTIME_CONVAR( p4ss_golden_goal, 1, "Enables golden goal state when stalemate would happen." );
 PASSTIME_CONVAR( p4ss_lock_eye_to_eye_los, 1, "Check LOS eye-to-eye when trying to lock-on." );
 PASSTIME_CONVAR( p4ss_whistle_more, 1, "Allows users to whistle in more use cases." );
+PASSTIME_CONVAR( p4ss_heal_on_pass, 0, "How many HP you recieve when ball is passed to you." );
+PASSTIME_CONVAR( p4ss_heal_on_pass_flight_time, 2, "How many seconds between passes for a pass to heal." );
+PASSTIME_CONVAR( p4ss_minicrit_protection_time, 3, "How many seconds you are protected from minicrits after picking up the ball." );

--- a/src/game/shared/tf/passtime_convars.h
+++ b/src/game/shared/tf/passtime_convars.h
@@ -80,7 +80,10 @@ extern ConVar
 
 	p4ss_golden_goal,
 	p4ss_lock_eye_to_eye_los,
-	p4ss_whistle_more;
+	p4ss_whistle_more,
+	p4ss_heal_on_pass,
+	p4ss_heal_on_pass_flight_time,
+	p4ss_minicrit_protection_time;
 
 enum class EPasstimeExperiment_Telepass { 
 	None,


### PR DESCRIPTION
New minicrits scenarios while holding jack.
Also health convars added for pass received.
Fixes #292

<!--
Ensure your contributions and code are your own original contributions, and that you are giving them over to us (passtime.tf) to use in this project and any other subprojects based on this source code.
-->

# Description
### Rework on carrying the jack
- Always take minicrit while explosive jumping.
- If you are within pack-range during any of the first `p4ss_minicrit_protection_time` seconds of grabbing the ball; you will be protected from minicrits for the remainder of that time. 
- After `p4ss_minicrit_protection_time` seconds you will ALWAYS take minicrits. To reset it, another player HAS to have held the ball. 

PASSTIME_CONVAR( p4ss_minicrit_protection_time, 3, "How many seconds you are protected from minicrits after picking up the ball." );

### Health on pass received
Passing the ball while having waited enough time between passes will grant you health.

PASSTIME_CONVAR( p4ss_heal_on_pass, 0, "How many HP you recieve when ball is passed to you." );
PASSTIME_CONVAR( p4ss_heal_on_pass_flight_time, 2, "How many seconds between passes for a pass to heal." );
