### PR TITLE
Allow weapon pickup while reloading

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -22813,8 +22813,9 @@ bool CTFPlayer::TryToPickupDroppedWeapon()
 	if ( !CanAttack() )
 		return false;
 
-	if ( GetActiveWeapon() && ( GetActiveWeapon()->m_flNextPrimaryAttack > gpGlobals->curtime ) )
-		return false;
+	// Disabled to allow picking up weapons while reloading
+	// if ( GetActiveWeapon() && ( GetActiveWeapon()->m_flNextPrimaryAttack > gpGlobals->curtime ) )
+	// 	return false;
 
 	CTFDroppedWeapon *pDroppedWeapon = GetDroppedWeaponInRange();
 	if ( pDroppedWeapon && !pDroppedWeapon->IsMarkedForDeletion() )


### PR DESCRIPTION
Since auto reload is on for everyone, it makes it difficult to pick up weapons from the ground unless you wait for your weapon to fully reload.

Closes p4sstime/p4ss#254