### PR TITLE
Updated GreyBG in minmode to be properly scaled

### DIFF
--- a/game/p4ss/resource/ui/hudpasstimeteamscore.res
+++ b/game/p4ss/resource/ui/hudpasstimeteamscore.res
@@ -24,7 +24,7 @@
 		"zpos"			"0"
 		"wide"			"156"
 		"tall"			"26"
-		"wide_minmode"	"57"
+		"wide_minmode"	"58"
 		"tall_minmode"	"26"
 		"visible"		"1"
 		"enabled"		"1"


### PR DESCRIPTION
the bg was slightly narrower on the right side then it was on the left

<img width="344" height="146" alt="pfhudcommit" src="https://github.com/user-attachments/assets/cf2550ef-a578-4fef-9672-0c1582139a8c" />
