### PR TITLE
Magnet sound is killed in deconstructor.

### DIFF
--- a/src/game/server/tf/tf_passtime_ball.cpp
+++ b/src/game/server/tf/tf_passtime_ball.cpp
@@ -500,6 +500,8 @@ CPasstimeBall::~CPasstimeBall()
 	{
 		CSoundEnvelopeController::GetController().SoundDestroy( m_pBeepLoop );
 	}
+
+	KillMagnetSound();
 }
 
 //-----------------------------------------------------------------------------
@@ -661,6 +663,8 @@ void CPasstimeBall::SetStateOutOfPlay()
 		CSoundEnvelopeController::GetController().SoundDestroy( m_pBeepLoop );
 		m_pBeepLoop = 0;
 	}
+
+	KillMagnetSound();
 
 	//
 	// Bookeeping


### PR DESCRIPTION
#349

<!--
Ensure your contributions and code are your own original contributions, and that you are giving them over to us (passtime.tf) to use in this project and any other subprojects based on this source code.
-->

# Description
Fixes Solarlights one in a gazillion bug where you would almost pick up the ball and then have it despawn keeping the magnet sound playing forever.