### PR TITLE
Convar turns off soldier groan for RJ

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9207,7 +9207,10 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 
 	if ( m_iHealthBefore != GetHealth() )
 	{
-		PainSound( info );
+		if ( !p4ss_mute_rocket_jump_groan.GetBool() && !bIsSoldierRocketJumping )
+		{
+			PainSound( info );
+		}
 	}
 
 	// Detect drops below 25% health and restart expression, so that characters look worried.

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -277,7 +277,7 @@ extern ConVar sv_vote_allow_spectators;
 ConVar sv_vote_late_join_time( "sv_vote_late_join_time", "90", FCVAR_NONE, "Grace period after the match starts before players who join the match receive a vote-creation cooldown" );
 ConVar sv_vote_late_join_cooldown( "sv_vote_late_join_cooldown", "300", FCVAR_NONE, "Length of the vote-creation cooldown when joining the server after the grace period has expired" );
 
-ConVar	p4ss_mute_rocket_jump_groan	( "p4ss_mute_rocket_jump_groan","1", FCVAR_USERINFO, "Mutes rocket jump pain groan on client side." );
+ConVar	pf_mute_rocket_jump_groan	( "pf_mute_rocket_jump_groan","1", FCVAR_USERINFO, "Mutes rocket jump pain groan on client side." );
 
 extern ConVar tf_feign_death_duration;
 extern ConVar spec_freeze_time;
@@ -14188,7 +14188,7 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 	}
 
 	// speak a louder pain concept to just the attacker
-	if ( bAttackerIsPlayer && !( p4ss_mute_rocket_jump_groan.GetBool() && bIsSoldierRocketJumping ) )
+	if ( bAttackerIsPlayer && !( pf_mute_rocket_jump_groan.GetBool() && bIsSoldierRocketJumping ) )
 	{
 		CSingleUserRecipientFilter attackerFilter( ToBasePlayer( info.GetAttacker() ) );
 		SpeakConceptIfAllowed( MP_CONCEPT_PLAYER_ATTACKER_PAIN, "damagecritical:1", szResponse, AI_Response::MAX_RESPONSE_NAME, &attackerFilter );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -14157,11 +14157,6 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 
 	bool bAttackerIsPlayer = ( info.GetAttacker() && info.GetAttacker()->IsPlayer() );
 	bool bIsSoldierRocketJumping = ( IsPlayerClass( TF_CLASS_SOLDIER ) && ( info.GetAttacker() == this ) && !( GetFlags() & FL_ONGROUND ) && !( GetFlags() & FL_INWATER ) ) && ( info.GetDamageType() & DMG_BLAST );
-	
-	if ( p4ss_mute_rocket_jump_groan.GetBool() && bIsSoldierRocketJumping )
-		{
-			return;
-		}
 
 	CMultiplayer_Expresser *pExpresser = GetMultiplayerExpresser();
 	Assert( pExpresser );
@@ -14193,7 +14188,7 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 	}
 
 	// speak a louder pain concept to just the attacker
-	if ( bAttackerIsPlayer )
+	if ( bAttackerIsPlayer && !( p4ss_mute_rocket_jump_groan.GetBool() && bIsSoldierRocketJumping ) )
 	{
 		CSingleUserRecipientFilter attackerFilter( ToBasePlayer( info.GetAttacker() ) );
 		SpeakConceptIfAllowed( MP_CONCEPT_PLAYER_ATTACKER_PAIN, "damagecritical:1", szResponse, AI_Response::MAX_RESPONSE_NAME, &attackerFilter );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -277,6 +277,8 @@ extern ConVar sv_vote_allow_spectators;
 ConVar sv_vote_late_join_time( "sv_vote_late_join_time", "90", FCVAR_NONE, "Grace period after the match starts before players who join the match receive a vote-creation cooldown" );
 ConVar sv_vote_late_join_cooldown( "sv_vote_late_join_cooldown", "300", FCVAR_NONE, "Length of the vote-creation cooldown when joining the server after the grace period has expired" );
 
+ConVar	p4ss_mute_rocket_jump_groan	( "p4ss_mute_rocket_jump_groan","1", FCVAR_USERINFO, "Mutes rocket jump pain groan on client side." );
+
 extern ConVar tf_feign_death_duration;
 extern ConVar spec_freeze_time;
 extern ConVar spec_freeze_traveltime;
@@ -9207,10 +9209,7 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 
 	if ( m_iHealthBefore != GetHealth() )
 	{
-		if ( !p4ss_mute_rocket_jump_groan.GetBool() && !bIsSoldierRocketJumping )
-		{
-			PainSound( info );
-		}
+		PainSound( info );
 	}
 
 	// Detect drops below 25% health and restart expression, so that characters look worried.
@@ -14157,6 +14156,12 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 	float flPainLength = 0;
 
 	bool bAttackerIsPlayer = ( info.GetAttacker() && info.GetAttacker()->IsPlayer() );
+	bool bIsSoldierRocketJumping = ( IsPlayerClass( TF_CLASS_SOLDIER ) && ( info.GetAttacker() == this ) && !( GetFlags() & FL_ONGROUND ) && !( GetFlags() & FL_INWATER ) ) && ( info.GetDamageType() & DMG_BLAST );
+	
+	if ( p4ss_mute_rocket_jump_groan.GetBool() && bIsSoldierRocketJumping )
+		{
+			return;
+		}
 
 	CMultiplayer_Expresser *pExpresser = GetMultiplayerExpresser();
 	Assert( pExpresser );

--- a/src/game/shared/tf/passtime_convars.cpp
+++ b/src/game/shared/tf/passtime_convars.cpp
@@ -90,4 +90,3 @@ PASSTIME_CONVAR( p4ss_whistle_more, 1, "Allows users to whistle in more use case
 PASSTIME_CONVAR( p4ss_heal_on_pass, 0, "How many HP you recieve when ball is passed to you." );
 PASSTIME_CONVAR( p4ss_heal_on_pass_flight_time, 2, "How many seconds between passes for a pass to heal." );
 PASSTIME_CONVAR( p4ss_minicrit_protection_time, 3, "How many seconds you are protected from minicrits after picking up the ball." );
-PASSTIME_CONVAR( p4ss_mute_rocket_jump_groan, 1, "Disables pain sound from soldier when rocket jumping." );

--- a/src/game/shared/tf/passtime_convars.cpp
+++ b/src/game/shared/tf/passtime_convars.cpp
@@ -90,3 +90,4 @@ PASSTIME_CONVAR( p4ss_whistle_more, 1, "Allows users to whistle in more use case
 PASSTIME_CONVAR( p4ss_heal_on_pass, 0, "How many HP you recieve when ball is passed to you." );
 PASSTIME_CONVAR( p4ss_heal_on_pass_flight_time, 2, "How many seconds between passes for a pass to heal." );
 PASSTIME_CONVAR( p4ss_minicrit_protection_time, 3, "How many seconds you are protected from minicrits after picking up the ball." );
+PASSTIME_CONVAR( p4ss_mute_rocket_jump_groan, 1, "Disables pain sound from soldier when rocket jumping." );

--- a/src/game/shared/tf/passtime_convars.h
+++ b/src/game/shared/tf/passtime_convars.h
@@ -87,7 +87,9 @@ extern ConVar
 	p4ss_whistle_more,
 	p4ss_heal_on_pass,
 	p4ss_heal_on_pass_flight_time,
-	p4ss_minicrit_protection_time;
+	p4ss_minicrit_protection_time,
+
+	p4ss_mute_rocket_jump_groan;
 
 enum class EPasstimeExperiment_Telepass { 
 	None,

--- a/src/game/shared/tf/passtime_convars.h
+++ b/src/game/shared/tf/passtime_convars.h
@@ -87,9 +87,7 @@ extern ConVar
 	p4ss_whistle_more,
 	p4ss_heal_on_pass,
 	p4ss_heal_on_pass_flight_time,
-	p4ss_minicrit_protection_time,
-
-	p4ss_mute_rocket_jump_groan;
+	p4ss_minicrit_protection_time;
 
 enum class EPasstimeExperiment_Telepass { 
 	None,


### PR DESCRIPTION
#357
p4ss_mute_rocket_jump_groan 1/0

<!--
Ensure your contributions and code are your own original contributions, and that you are giving them over to us (passtime.tf) to use in this project and any other subprojects based on this source code.
-->

# Description
This convar adds ability to mute solly's groaning while rjing.