### PR TITLE
Fix +resupply command in default_config

### DIFF
--- a/game/p4ss/cfg/config_default.cfg
+++ b/game/p4ss/cfg/config_default.cfg
@@ -38,7 +38,7 @@ bind	"F4"			"player_ready_toggle"
 bind	"MOUSE1"		"+attack"
 bind	"MOUSE2"		"+attack2"
 
-bind	"r"				"resupply"
+bind	"r"				"+resupply"
 bind	"MWHEELUP"		"invprev"
 bind	"MWHEELDOWN"	"invnext"
 bind	"q"				"lastinv"


### PR DESCRIPTION
Now that resupply is buffered, the key must be held down, and therefore changed to +resupply.
closes #380 