### PR TITLE
feat: Add immune time to ball after thrown.

### DIFF
--- a/src/game/server/tf/tf_passtime_ball.cpp
+++ b/src/game/server/tf/tf_passtime_ball.cpp
@@ -551,6 +551,7 @@ void CPasstimeBall::OnBecomeNotCarried()
 	SetParent( 0 );
 }
 
+// Applied when throwing the ball, when the ball spawns, and when dying with the ball
 //-----------------------------------------------------------------------------
 void CPasstimeBall::SetStateFree()
 {
@@ -584,6 +585,9 @@ void CPasstimeBall::SetStateFree()
 	{
 		m_flThrowerCanPickupTime = gpGlobals->curtime + tf_passtime_no_jack_armor_time.GetFloat();
 	}
+
+	// Set ball immunity length after being thrown
+	m_flBallDmgImmuneTime = gpGlobals->curtime + tf_passtime_ball_dmg_immune_time.GetFloat();
 	
 	TFGameRules()->SetObjectiveObserverTarget( this );
 	VPhysicsGetObject()->EnableGravity( true );
@@ -1375,7 +1379,7 @@ int	CPasstimeBall::OnTakeDamage( const CTakeDamageInfo &info )
 {
 	CTFPlayer *ballThrower = GetThrower();
 
-	if ( !tf_passtime_ball_takedamage.GetBool() )
+	if ( !tf_passtime_ball_takedamage.GetBool() || gpGlobals->curtime < GetBallDmgImmuneTime())
 	{
 		// this can happen if the cvar is disabled after the ball has spawned
 		return 0;
@@ -1411,8 +1415,7 @@ int	CPasstimeBall::OnTakeDamage( const CTakeDamageInfo &info )
 		Ray_t ray;
 
 		ray.Init( inflictorOrigin, ballOrigin );
-		UTIL_TraceRay( ray, MASK_SOLID, inflictor,
-COLLISION_GROUP_WEAPON, &result );
+		UTIL_TraceRay( ray, MASK_SOLID, inflictor, COLLISION_GROUP_WEAPON, &result );
 
 		if ( result.DidHit() ) // ball direct
 		{
@@ -1457,22 +1460,15 @@ COLLISION_GROUP_WEAPON, &result );
 			{
 				if ( didSplashGoal && attackerPlayer && ballThrower && attackerPlayer->GetTeamNumber() != ballThrower->GetTeamNumber() )
 				{
-					PasstimeGameEvents::BallSplashed(
-					attackerPlayer->entindex(), weaponname, true )
-					.Fire();
+					PasstimeGameEvents::BallSplashed( attackerPlayer->entindex(), weaponname, true ).Fire();
 				}
 				else
 				{
-					PasstimeGameEvents::BallDirected(
-					attackerPlayer->entindex(), inflictor->entindex(), weaponname )
-					.Fire();				
+					PasstimeGameEvents::BallDirected( attackerPlayer->entindex(), inflictor->entindex(), weaponname ).Fire();				
 				}
 
 			} else if ( didSplashGoal && attackerPlayer && ballThrower && attackerPlayer->GetTeamNumber() != ballThrower->GetTeamNumber() ) { // ball splash
-
-					PasstimeGameEvents::BallSplashed(
-					attackerPlayer->entindex(), weaponname, false )
-					.Fire();
+					PasstimeGameEvents::BallSplashed( attackerPlayer->entindex(), weaponname, false ).Fire();
 			} 
 		}
 
@@ -1654,6 +1650,10 @@ float CPasstimeBall::GetThrowerCanPickupTime() const
 	return m_flThrowerCanPickupTime;
 }
 
+float CPasstimeBall::GetBallDmgImmuneTime() const
+{
+	return m_flBallDmgImmuneTime;
+}
 
 void CPasstimeBall::CreateMagnetSound()
 {

--- a/src/game/server/tf/tf_passtime_ball.h
+++ b/src/game/server/tf/tf_passtime_ball.h
@@ -79,6 +79,7 @@ public:
 	float GetAirtimeSec() const;
 	float GetAirtimeDistance() const;
 	float GetThrowerCanPickupTime() const;
+	float GetBallDmgImmuneTime() const;
 
 	void StartLagCompensation( CBasePlayer *player, CUserCmd *cmd );
 	void FinishLagCompensation( CBasePlayer *player );
@@ -129,7 +130,8 @@ private:
 	float m_flLastTeamChangeTime; // for stats
 	float m_flBeginCarryTime;
 	float m_flIdleRespawnTime;
-	float m_flThrowerCanPickupTime; // for jack armor prevention
+	float m_flThrowerCanPickupTime; // jack armor prevention
+	float m_flBallDmgImmuneTime; // instant splash prevention
 
 	CUtlVector<CBaseEntity*> m_mapGoals; 
 

--- a/src/game/server/tf/tf_passtime_logic.cpp
+++ b/src/game/server/tf/tf_passtime_logic.cpp
@@ -1316,6 +1316,7 @@ void CTFPasstimeLogic::SetLastPassTime( CTFPlayer* pPlayer )
 	}
 }
 
+// Send the ball straight up when the player holding it died.
 //-----------------------------------------------------------------------------
 void CTFPasstimeLogic::EjectBall( CTFPlayer *pPlayer, CTFPlayer *pAttacker )
 {

--- a/src/game/shared/tf/passtime_convars.cpp
+++ b/src/game/shared/tf/passtime_convars.cpp
@@ -78,20 +78,21 @@ PASSTIME_CONVAR( tf_passtime_pack_speed,                  1, "When set to 1, all
 PASSTIME_CONVAR( tf_passtime_pack_hp_per_sec,             2.0f, "How many HP per second pack members are healed." );
 
 // med splashing
-PASSTIME_CONVAR( p4ss_med_cansplash,              1,    "Enables med splashing." );
-PASSTIME_CONVAR( p4ss_med_canpushball,            1,    "Enables med pushing ball with crossbow." );
-PASSTIME_CONVAR( p4ss_med_canheadshot,            0,    "Enables med headshotting with crossbow." );
-PASSTIME_CONVAR( p4ss_med_crossbow_damagefalloff, -1,   "Sets damage falloff for crossbow. [-1, 0, 1]" );
-PASSTIME_CONVAR( p4ss_med_crossbow_heal_mult,     2.0f, "Sets heal multiplier for crossbow. " );
+PASSTIME_CONVAR( p4ss_med_cansplash,              1,      "Enables med splashing." );
+PASSTIME_CONVAR( p4ss_med_canpushball,            1,      "Enables med pushing ball with crossbow." );
+PASSTIME_CONVAR( p4ss_med_canheadshot,            0,      "Enables med headshotting with crossbow." );
+PASSTIME_CONVAR( p4ss_med_crossbow_damagefalloff, -1,     "Sets damage falloff for crossbow. [-1, 0, 1]" );
+PASSTIME_CONVAR( p4ss_med_crossbow_heal_mult,     2.0f,   "Sets heal multiplier for crossbow. " );
 
-PASSTIME_CONVAR( p4ss_golden_goal,                1,     "Enables golden goal state when stalemate would happen." );
-PASSTIME_CONVAR( p4ss_lock_eye_to_eye_los,        1,     "Check LOS eye-to-eye when trying to lock-on." );
-PASSTIME_CONVAR( p4ss_whistle_more,               1,     "Allows users to whistle in more use cases." );
-PASSTIME_CONVAR( p4ss_heal_on_pass,               0,     "How many HP you recieve when ball is passed to you." );
-PASSTIME_CONVAR( p4ss_heal_on_pass_flight_time,   2,     "How many seconds between passes for a pass to heal." );
-PASSTIME_CONVAR( p4ss_minicrit_protection_time,   3,     "How many seconds you are protected from minicrits after picking up the ball." );
-PASSTIME_CONVAR( p4ss_lock_max_turn_angle,        90,    "Maximum angle in degrees you can turn away from locked target before unlocking. 0 to disable." );
-PASSTIME_CONVAR( p4ss_passtime_lock_angle,        15.0f, "Maximum cone angle in degrees from crosshair for lock-on detection." );
+PASSTIME_CONVAR( p4ss_golden_goal,                1,      "Enables golden goal state when stalemate would happen." );
+PASSTIME_CONVAR( p4ss_lock_eye_to_eye_los,        1,      "Check LOS eye-to-eye when trying to lock-on." );
+PASSTIME_CONVAR( p4ss_whistle_more,               1,      "Allows users to whistle in more use cases." );
+PASSTIME_CONVAR( p4ss_heal_on_pass,               0,      "How many HP you recieve when ball is passed to you." );
+PASSTIME_CONVAR( p4ss_heal_on_pass_flight_time,   2,      "How many seconds between passes for a pass to heal." );
+PASSTIME_CONVAR( p4ss_minicrit_protection_time,   3,      "How many seconds you are protected from minicrits after picking up the ball." );
+PASSTIME_CONVAR( p4ss_lock_max_turn_angle,        90,     "Maximum angle in degrees you can turn away from locked target before unlocking. 0 to disable." );
+PASSTIME_CONVAR( p4ss_passtime_lock_angle,        15.0f,  "Maximum cone angle in degrees from crosshair for lock-on detection." );
 
-PASSTIME_CONVAR( tf_passtime_no_jack_armor, 1, "Prevents ball thrower from immediately grabbing the ball." );
-PASSTIME_CONVAR( tf_passtime_no_jack_armor_time, 0.25f, "How many seconds the thrower must wait before picking up the ball again." );
+PASSTIME_CONVAR( tf_passtime_no_jack_armor,        1,     "Prevents ball thrower from immediately grabbing the ball." );
+PASSTIME_CONVAR( tf_passtime_no_jack_armor_time,   0.25f, "How many seconds the thrower must wait before picking up the ball again." );
+PASSTIME_CONVAR( tf_passtime_ball_dmg_immune_time, 0.25f, "How long in seconds is the ball immune to splash damage neutralising the ball");

--- a/src/game/shared/tf/passtime_convars.h
+++ b/src/game/shared/tf/passtime_convars.h
@@ -92,7 +92,8 @@ extern ConVar
 	p4ss_passtime_lock_angle,
 
 	tf_passtime_no_jack_armor,
-	tf_passtime_no_jack_armor_time;
+	tf_passtime_no_jack_armor_time,
+	tf_passtime_ball_dmg_immune_time;
     
     enum class EPasstimeExperiment_Telepass { 
 	None,


### PR DESCRIPTION
Adds ``tf_passtime_ball_dmg_immune_time`` which controls how long the ball is immune to splashing after being thrown, ejected (owner died) and spawned (start of the round).

Tested locally, works fine.

closes #389