### PR TITLE
Fixed event text staying on screen after disconnecting and joining a new match

### DIFF
--- a/src/game/client/tf/tf_hud_passtime.cpp
+++ b/src/game/client/tf/tf_hud_passtime.cpp
@@ -758,6 +758,7 @@ void CTFHudPasstimeEventText::Tick()
 //-----------------------------------------------------------------------------
 void CTFHudPasstimeEventText::Clear()
 {
+	m_displayTimer.Invalidate();
 	while( !m_queue.IsEmpty() )
 	{
 		m_queue.RemoveAtTail();


### PR DESCRIPTION
Closes #393 
