### PR TITLE
Shortnames in more places and enabled by default

### DIFF
--- a/src/game/client/hud_voicestatus.cpp
+++ b/src/game/client/hud_voicestatus.cpp
@@ -16,7 +16,22 @@
 #include "voice_common.h"
 #include "vgui_avatarimage.h"
 
+#include "c_tf_player.h" //added for shortnames
+
 ConVar *sv_alltalk = NULL;
+
+const char *GetPlayerVoiceStatusName( int iPlayerIndex )
+{
+	if ( pf_use_shortnames.GetBool() )
+	{
+		static char szShortName[MAX_PLAYER_NAME_LENGTH];
+		const wchar_t *wszShortName = GetPlayerShortName( iPlayerIndex );
+		g_pVGuiLocalize->ConvertUnicodeToANSI( wszShortName, szShortName,
+											   sizeof( szShortName ) );
+		return szShortName;
+	}
+	return g_PR->GetPlayerName( iPlayerIndex );
+}
 
 //=============================================================================
 // Icon for the local player using voice
@@ -359,7 +374,7 @@ void CHudVoiceStatus::Paint()
 
 		c[3] = 128;
 
-		const char *pName = g_PR ? g_PR->GetPlayerName(playerId) : "unknown";
+		const char *pName = g_PR ? GetPlayerVoiceStatusName(playerId) : "unknown";
 		wchar_t szconverted[ 64 ];
 
 		// Add the location, if any

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -224,6 +224,9 @@ ConVar tf_romevision_skip_prompt( "tf_romevision_skip_prompt", "0", FCVAR_ARCHIV
 
 ConVar tf_chat_particle( "tf_chat_particle", "1", FCVAR_ARCHIVE, "Show typing bubble above player heads" );
 
+//Wasn't sure where else to put this.
+ConVar pf_use_shortnames( "pf_use_shortnames", "1", FCVAR_ARCHIVE, "Use short nicknames in place of regular, Steam usernames." );
+
 #define BDAY_HAT_MODEL		"models/effects/bday_hat.mdl"
 #define BOMB_HAT_MODEL		"models/props_lakeside_event/bomb_temp_hat.mdl"
 #define BOMBONOMICON_MODEL  "models/props_halloween/bombonomicon.mdl"

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -44,6 +44,9 @@ extern ConVar tf_medigun_autoheal;
 extern ConVar cl_autorezoom;
 extern ConVar cl_autoreload;
 
+//Was not sure where else to put this.
+extern ConVar pf_use_shortnames;
+
 enum EBonusEffectFilter_t
 {
 	kEffectFilter_AttackerOnly,

--- a/src/game/client/tf/tf_hud_deathnotice.cpp
+++ b/src/game/client/tf/tf_hud_deathnotice.cpp
@@ -54,11 +54,9 @@ ConVar cl_hud_killstreak_display_time( "cl_hud_killstreak_display_time", "3", FC
 ConVar cl_hud_killstreak_display_fontsize( "cl_hud_killstreak_display_fontsize", "0", FCVAR_ARCHIVE, "Adjusts font size of killstreak notices.  Range is from 0 to 2 (default is 1)." );
 ConVar cl_hud_killstreak_display_alpha( "cl_hud_killstreak_display_alpha", "120", FCVAR_ARCHIVE, "Adjusts font alpha value of killstreak notices.  Range is from 0 to 255 (default is 200)." );
 
-ConVar pf_killfeed_use_nicks( "pf_killfeed_use_nicks", "0", FCVAR_ARCHIVE, "Use short nicknames in the killfeed instead of full names." );
-
 const char* GetPlayerDeathNoticeName( int iPlayerIndex )
 {
-	if ( pf_killfeed_use_nicks.GetBool() )
+	if ( pf_use_shortnames.GetBool() )
 	{
 		static char szShortName[MAX_PLAYER_NAME_LENGTH];
 		const wchar_t *wszShortName = GetPlayerShortName( iPlayerIndex );

--- a/src/game/client/tf/tf_hud_freezepanel.cpp
+++ b/src/game/client/tf/tf_hud_freezepanel.cpp
@@ -51,6 +51,19 @@ extern float g_flFreezeFlash;
 
 extern ConVar hud_freezecamhide;
 
+const char *GetPlayerFreezecamName( int iPlayerIndex )
+{
+	if ( pf_use_shortnames.GetBool() )
+	{
+		static char szShortName[MAX_PLAYER_NAME_LENGTH];
+		const wchar_t *wszShortName = GetPlayerShortName( iPlayerIndex );
+		g_pVGuiLocalize->ConvertUnicodeToANSI( wszShortName, szShortName,
+											   sizeof( szShortName ) );
+		return szShortName;
+	}
+	return g_PR->GetPlayerName( iPlayerIndex );
+}
+
 bool IsTakingAFreezecamScreenshot( void )
 {
 	// Don't draw in freezecam, or when the game's not running
@@ -400,7 +413,7 @@ void CTFFreezePanel::FireGameEvent( IGameEvent * event )
 					}
 				}
 
-				m_pBasePanel->SetDialogVariable( "killername", g_PR->GetPlayerName( m_iKillerIndex ) );
+				m_pBasePanel->SetDialogVariable( "killername", GetPlayerFreezecamName( m_iKillerIndex ) );
 
 				if ( m_pAvatar )
 				{
@@ -434,7 +447,7 @@ void CTFFreezePanel::FireGameEvent( IGameEvent * event )
 					item.SetInitialized( true );
 					item.SetItemOriginOverride( kEconItemOrigin_Invalid );
 
-					m_pItemPanel->SetDialogVariable( "killername", g_PR->GetPlayerName( m_iKillerIndex ) );
+					m_pItemPanel->SetDialogVariable( "killername", GetPlayerFreezecamName( m_iKillerIndex ) );
 					m_pItemPanel->SetItem( &item );
 					m_pItemPanel->SetVisible( true );
 				}
@@ -455,10 +468,10 @@ void CTFFreezePanel::FireGameEvent( IGameEvent * event )
 								CBasePlayer *pOriginalOwner = GetPlayerByAccountID( pItemToShow->GetAccountID() );
 								bool bOriginalOwner = !pOriginalOwner || pOriginalOwner == pKiller;
 								pItemLabel->SetText( bOriginalOwner ? "#FreezePanel_Item" : "#FreezePanel_ItemOtherOwner" );
-								m_pItemPanel->SetDialogVariable( "ownername", pOriginalOwner ? g_PR->GetPlayerName( pOriginalOwner->entindex() ) : "" );
+								m_pItemPanel->SetDialogVariable( "ownername", pOriginalOwner ? GetPlayerFreezecamName( pOriginalOwner->entindex() ) : "" );
 							}
 
-							m_pItemPanel->SetDialogVariable( "killername", g_PR->GetPlayerName( m_iKillerIndex ) );
+							m_pItemPanel->SetDialogVariable( "killername", GetPlayerFreezecamName( m_iKillerIndex ) );
 							m_pItemPanel->SetItem( pItemToShow );
 							m_pItemPanel->SetVisible( true );
 						}
@@ -479,7 +492,7 @@ void CTFFreezePanel::FireGameEvent( IGameEvent * event )
 				{
 					m_iKillerIndex = pTFPlayerKiller->entindex();
 
-					m_pBasePanel->SetDialogVariable( "killername", g_PR->GetPlayerName( m_iKillerIndex ) );
+					m_pBasePanel->SetDialogVariable( "killername", GetPlayerFreezecamName( m_iKillerIndex ) );
 
 					if ( m_pAvatar )
 					{
@@ -1128,7 +1141,7 @@ int	CTFFreezePanel::HudElementKeyInput( int down, ButtonCode_t keynum, const cha
 				//Set the screenshot name
 				if ( m_iKillerIndex <= MAX_PLAYERS )
 				{
-					const char *pszKillerName = g_PR->GetPlayerName( m_iKillerIndex );
+					const char *pszKillerName = GetPlayerFreezecamName( m_iKillerIndex );
 
 					if ( pszKillerName )
 					{

--- a/src/game/client/tf/tf_hud_winpanel.cpp
+++ b/src/game/client/tf/tf_hud_winpanel.cpp
@@ -108,6 +108,19 @@ void CTFWinPanel::SetVisible( bool state )
 	BaseClass::SetVisible( state );
 }
 
+const char *GetPlayerWinPanelName( int iPlayerIndex )
+{
+	if ( pf_use_shortnames.GetBool() )
+	{
+		static char szShortName[MAX_PLAYER_NAME_LENGTH];
+		const wchar_t *wszShortName = GetPlayerShortName( iPlayerIndex );
+		g_pVGuiLocalize->ConvertUnicodeToANSI( wszShortName, szShortName,
+											   sizeof( szShortName ) );
+		return szShortName;
+	}
+	return g_PR->GetPlayerName( iPlayerIndex );
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -433,7 +446,7 @@ void CTFWinPanel::FireGameEvent( IGameEvent * event )
 				wchar_t wzCapMsg[512]=L"";
 				for ( int i = 0; i < iCappers; i++ )
 				{
-					Q_strncat( szPlayerNames, g_PR->GetPlayerName( (int) pCappers[i] ), ARRAYSIZE( szPlayerNames ) );
+					Q_strncat( szPlayerNames, GetPlayerWinPanelName( (int) pCappers[i] ), ARRAYSIZE( szPlayerNames ) );
 					if ( i < iCappers - 1 )
 					{
 						Q_strncat( szPlayerNames, ", ", ARRAYSIZE( szPlayerNames ) );
@@ -521,7 +534,7 @@ void CTFWinPanel::FireGameEvent( IGameEvent * event )
 				pPlayerScore->SetFgColor( clr );
 
 				// set label contents
-				pPlayerName->SetText( g_PR->GetPlayerName( iPlayerIndex ) );
+				pPlayerName->SetText( GetPlayerWinPanelName( iPlayerIndex ) );
 				pPlayerClass->SetText( g_aPlayerClassNames[g_TF_PR->GetPlayerClass( iPlayerIndex )] );
 				pPlayerScore->SetText( CFmtStr( "%d", iRoundScore ) );
 
@@ -577,7 +590,7 @@ void CTFWinPanel::FireGameEvent( IGameEvent * event )
 				pKillStreakPlayerScore->SetFgColor( clr );
 
 				// set label contents
-				pKillStreakPlayerName->SetText( g_PR->GetPlayerName( iPlayerIndex ) );
+				pKillStreakPlayerName->SetText( GetPlayerWinPanelName( iPlayerIndex ) );
 				pKillStreakPlayerClass->SetText( g_aPlayerClassNames[g_TF_PR->GetPlayerClass( iPlayerIndex )] );
 				pKillStreakPlayerScore->SetText( CFmtStr( "%d", iCount ) );
 			}

--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -77,8 +77,6 @@ void cc_scoreboard_convar_changed( IConVar *pConVar, const char *pOldString, flo
 ConVar tf_scoreboard_ping_as_text( "tf_scoreboard_ping_as_text", "0", FCVAR_ARCHIVE, "Show ping values as text in the scoreboard.", cc_scoreboard_convar_changed );
 ConVar tf_scoreboard_alt_class_icons( "tf_scoreboard_alt_class_icons", "0", FCVAR_ARCHIVE, "Show alternate class icons in the scoreboard." );
 
-ConVar pf_scoreboard_use_shortnames( "pf_scoreboard_use_shortnames", "0", FCVAR_ARCHIVE, "Use shortnames in place of player names in the scoreboard." );
-
 extern bool IsInCommentaryMode( void );
 extern void AddSubKeyNamed( KeyValues *pKeys, const char *pszName );
 
@@ -1157,7 +1155,7 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 			KeyValues *pKeyValues = new KeyValues( "data" );
 			pKeyValues->SetInt( "playerIndex", playerIndex );
 
-			if ( pf_scoreboard_use_shortnames.GetBool() )
+			if ( pf_use_shortnames.GetBool() )
 			{
 				pKeyValues->SetWString( "name", GetPlayerShortName( playerIndex ) );
 			}


### PR DESCRIPTION
Does the following:

* Merges pf_killfeed_use_nicks and pf_scoreboard_use_shortnames into one command, now called pf_use_shortnames
* Adds pf_use_shortnames support to the winpanel, freezecam and voice chat
* Enables pf_use_shortnames by default

Does **NOT** do the following:
* Edit text chat
* Edit the match HUD
* Edit the floating player names above heads
* Edit the PASS Time pass notifications or score notifications

I decided to stop here because I'm not savvy enough at this to do anything advanced. If anyone else wants to take a crack at this, a good suggestion was to append shortnames to chat messages (positioned before the full username, because it is shorter)