### PR TITLE
remove voice menu 2 and move 'incoming' to menu 3 (which is now menu 2)

### DIFF
--- a/game/p4ss/scripts/voicecommands.txt
+++ b/game/p4ss/scripts/voicecommands.txt
@@ -1,0 +1,177 @@
+
+// You can define up to 9 menus, each with up to 9 items
+
+
+//The parameters for an item:
+
+// "concept" - the AI concept to speak when the player chooses this item
+
+// "menu_label"    - localizable string to appear in the menu, add the matching string in tf_english
+//				   - will appear as: '<item number>. <localized string>', eg "#voice_menu_gogogo" leads to '1. Go Go Go'
+//						where ' "voice_menu_gogogo"  "Go Go Go" ' appears in tf_english
+
+// "show_subtitle" - set to 1 to print a subtitle to chat
+
+// "subtitle"      - localizable string that will print as the subtitle sent to teammates in hud chat
+
+// "distance_check_subtitle"    - if set to 1, only teammates in the PAS will get the subtitle, ie, if they hear the sound
+
+"voicemenus"
+{
+	"menu_1"
+	{
+		"item_1"
+		{
+			"concept"				"TLK_PLAYER_MEDIC"		
+			"menu_label"				"#Voice_Menu_Medic"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_Medic"
+			"activity"				"ACT_MP_GESTURE_VC_HANDMOUTH"
+		}
+		
+		"item_2"
+		{
+			"concept"				"TLK_PLAYER_THANKS"		
+			"menu_label"				"#Voice_Menu_Thanks"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_Thanks"
+			"activity"				"ACT_MP_GESTURE_VC_THUMBSUP"
+		}
+		
+		"item_3"
+		{
+			"concept"				"TLK_PLAYER_GO"	
+			"menu_label"				"#Voice_Menu_Go"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_Go"
+			"activity"				"ACT_MP_GESTURE_VC_FINGERPOINT"
+		}
+		
+		"item_4"
+		{
+			"concept"				"TLK_PLAYER_MOVEUP"		
+			"menu_label"				"#Voice_Menu_MoveUp"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_MoveUp"
+			"activity"				"ACT_MP_GESTURE_VC_FINGERPOINT"
+		}
+		
+		"item_5"
+		{
+			"concept"				"TLK_PLAYER_LEFT"		
+			"menu_label"				"#Voice_Menu_Left"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_Left"
+			"activity"				"ACT_MP_GESTURE_VC_FINGERPOINT"
+		}
+		
+		"item_6"
+		{
+			"concept"				"TLK_PLAYER_RIGHT"		
+			"menu_label"				"#Voice_Menu_Right"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_Right"
+			"activity"				"ACT_MP_GESTURE_VC_FINGERPOINT"
+		}
+		
+		"item_7"
+		{
+			"concept"				"TLK_PLAYER_YES"		
+			"menu_label"				"#Voice_Menu_Yes"
+			"show_subtitle"				"1"
+			"subtitle"				"#Voice_Menu_Yes"
+		}
+		
+		"item_8"
+		{
+			"concept"				"TLK_PLAYER_NO"	
+			"menu_label"				"#Voice_Menu_No"	
+			"show_subtitle"				"1"
+			"subtitle"				"#Voice_Menu_No"
+		}
+		"item_9"
+		{
+			"concept"				"TLK_PLAYER_ASK_FOR_BALL"
+			"distance_check_subtitle"		"0"
+			"show_subtitle"				"1"
+			"subtitle"				"#Voice_Menu_AskForBall"
+			"menu_label"				"#Voice_Menu_AskForBall"
+			"activity"				"ACT_MP_GESTURE_VC_FINGERPOINT"	
+		}
+	}
+
+	"menu_2"
+	{
+		"item_1"
+		{
+			"concept"				"TLK_PLAYER_HELP"
+			"menu_label"				"#Voice_Menu_Help"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_Help"
+			"activity"				"ACT_MP_GESTURE_VC_HANDMOUTH"
+		}
+
+		"item_2"
+		{
+			"concept"				"TLK_PLAYER_BATTLECRY"
+			"menu_label"				"#Voice_Menu_BattleCry"
+			"activity"				"ACT_MP_GESTURE_VC_FISTPUMP"
+		}
+		
+
+		"item_3"
+		{
+			"concept"				"TLK_PLAYER_CHEERS"
+			"menu_label"				"#Voice_Menu_Cheers"
+			"activity"				"ACT_MP_GESTURE_VC_FISTPUMP"
+		}
+		
+		"item_4"
+		{
+			"concept"				"TLK_PLAYER_JEERS"	
+			"menu_label"				"#Voice_Menu_Jeers"
+		}
+		
+		"item_5"
+		{
+			"concept"				"TLK_PLAYER_POSITIVE"		
+			"menu_label"				"#Voice_Menu_Positive"
+		}
+		
+		"item_6"
+		{
+			"concept"				"TLK_PLAYER_NEGATIVE"		
+			"menu_label"				"#Voice_Menu_Negative"
+		}
+		
+		"item_7"
+		{
+			"concept"				"TLK_PLAYER_NICESHOT"		
+			"menu_label"				"#Voice_Menu_NiceShot"
+			"activity"				"ACT_MP_GESTURE_VC_THUMBSUP"
+		}
+		
+		"item_8"
+		{
+			"concept"				"TLK_PLAYER_GOODJOB"		
+			"menu_label"				"#Voice_Menu_GoodJob"
+			"activity"				"ACT_MP_GESTURE_VC_THUMBSUP"
+		}
+		"item_9"
+		{
+			"concept"				"TLK_PLAYER_INCOMING"		
+			"menu_label"				"#Voice_Menu_Incoming"
+			"show_subtitle"				"1"
+			"distance_check_subtitle"		"1"
+			"subtitle"				"#Voice_Menu_Incoming"
+			"activity"				"ACT_MP_GESTURE_VC_HANDMOUTH"
+		}
+	}
+}

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -5840,7 +5840,7 @@ void C_TFPlayer::ClientThink()
 		//
 	    if ( m_afButtonPressed & IN_ATTACK3 )
 	    {
-		    engine->ClientCmd("voicemenu 1 8");
+		    engine->ClientCmd("voicemenu 0 8");
 	    }
 	}
 }


### PR DESCRIPTION
<img width="178" height="351" alt="Screenshot 2026-07-28 082302" src="https://github.com/user-attachments/assets/9761b5db-c035-4218-ac03-0913f3a89e9f" />

<img width="165" height="363" alt="Screenshot 2026-07-28 082306" src="https://github.com/user-attachments/assets/c4b274b9-1890-466c-9934-f557140f7174" />

There really isn't a need for 4 engineer voice commands, a spy voice command, and 2 uber voice commands in a mod that will have basically none of these. there was also a duplicate pass to me voice command in here...

only potential worry might be some muscle memory annoyance, but if players want they can rebind the new menu 2 to C to restore full muscle memory