### PR TITLE
Add a mapcycle file (server map rotation) for the new maps in the repo

### DIFF
--- a/game/p4ss/cfg/mapcycle_default.txt
+++ b/game/p4ss/cfg/mapcycle_default.txt
@@ -1,0 +1,14 @@
+// Default mapcycle file for PASS Fortress.
+//
+// DO NOT MODIFY THIS FILE!
+// Instead, copy it to mapcycle.txt and modify that file.  If no custom mapcycle.txt file is found,
+// this file will be used as the default.
+//
+// Also, note that the "mapcyclefile" convar can be used to specify a particular mapcycle file.
+
+pass_arena2_classic
+pass_boutique
+pass_stadium
+pass_stonework
+pass_plexiglass
+


### PR DESCRIPTION
This adds mapcycle_default.txt. Controls map rotation when the server is switching maps. Prior to this, the server was just reloading the map that was just played.
