### PR TITLE
Rework how classlimits work, among other tweaks

### DIFF
--- a/game/p4ss/resource/ui/classselection.res
+++ b/game/p4ss/resource/ui/classselection.res
@@ -206,7 +206,7 @@
 		"visible"			"1"
 		"enabled"			"1"
 		"tabPosition"		"0"
-		"labelText"			"2"	[$WIN32]
+		"labelText"			"1"	[$WIN32]
 		"labelText"			""		[$X360]
 		"textAlignment"		"south-west"
 		"Command"			"select 3"
@@ -355,7 +355,7 @@
 		"visible"			"1"
 		"enabled"			"1"
 		"tabPosition"		"0"
-		"labelText"			"4"	[$WIN32]
+		"labelText"			"2"	[$WIN32]
 		"labelText"			""		[$X360]
 		"textAlignment"		"south-west"
 		"Command"			"select 4"
@@ -559,7 +559,7 @@
 		"visible"			"1"
 		"enabled"			"1"
 		"tabPosition"		"0"
-		"labelText"			"7"	[$WIN32]
+		"labelText"			"3"	[$WIN32]
 		"labelText"			""		[$X360]
 		"textAlignment"		"south-west"
 		"Command"			"select 5"

--- a/src/game/client/tf/vgui/tf_classmenu.cpp
+++ b/src/game/client/tf/vgui/tf_classmenu.cpp
@@ -472,7 +472,7 @@ CTFClassMenu::CTFClassMenu( IViewPort *pViewPort )
 	m_mouseoverButtons.RemoveAll();
 
 	m_iClassMenuKey = BUTTON_CODE_INVALID;
-	m_iCurrentClassIndex = TF_CLASS_HEAVYWEAPONS;
+	m_iCurrentClassIndex = TF_CLASS_SOLDIER;
 
 #ifdef _X360
 	m_pFooter = new CTFFooter( this, "Footer" );

--- a/src/game/server/tf/tf_voteissues.cpp
+++ b/src/game/server/tf/tf_voteissues.cpp
@@ -979,7 +979,7 @@ float CNextLevelIssue::GetQuorumRatio( void )
 //-----------------------------------------------------------------------------
 // Purpose: Extend the current level
 //-----------------------------------------------------------------------------
-ConVar sv_vote_issue_extendlevel_allowed( "sv_vote_issue_extendlevel_allowed", "1", FCVAR_NONE, "Can players call votes to set the next level?" );
+ConVar sv_vote_issue_extendlevel_allowed( "sv_vote_issue_extendlevel_allowed", "0", FCVAR_NONE, "Can players call votes to set the next level?" );
 ConVar sv_vote_issue_extendlevel_quorum( "sv_vote_issue_extendlevel_quorum", "0.6", FCVAR_NONE, "What is the ratio of voters needed to reach quorum?" );
 
 //-----------------------------------------------------------------------------
@@ -1474,13 +1474,13 @@ float CTeamAutoBalanceIssue::GetQuorumRatio( void )
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: Enable/Disable tf_classlimit
+// Purpose: Enable/Disable tf_classlimit. Made development only in favor of using pf_classlimit_*
 //-----------------------------------------------------------------------------
-ConVar sv_vote_issue_classlimits_allowed( "sv_vote_issue_classlimits_allowed", "0", FCVAR_NONE, "Can players call votes to enable or disable per-class limits?" );
-ConVar sv_vote_issue_classlimits_allowed_mvm( "sv_vote_issue_classlimits_allowed_mvm", "0", FCVAR_NONE, "Can players call votes in Mann-Vs-Machine to enable or disable per-class limits?" );
-ConVar sv_vote_issue_classlimits_max( "sv_vote_issue_classlimits_max", "4", FCVAR_NONE, "Maximum number of players (per-team) that can be any one class.", true, 1.f, false, 16.f );
-ConVar sv_vote_issue_classlimits_max_mvm( "sv_vote_issue_classlimits_max_mvm", "2", FCVAR_NONE, "Maximum number of players (per-team) that can be any one class.", true, 1.f, false, 16.f );
-ConVar sv_vote_issue_classlimits_cooldown( "sv_vote_issue_classlimits_cooldown", "300", FCVAR_NONE, "Minimum time before another classlimits vote can occur (in seconds)." );
+ConVar sv_vote_issue_classlimits_allowed( "sv_vote_issue_classlimits_allowed", "0", FCVAR_DEVELOPMENTONLY, "Can players call votes to enable or disable per-class limits?" );
+ConVar sv_vote_issue_classlimits_allowed_mvm( "sv_vote_issue_classlimits_allowed_mvm", "0", FCVAR_DEVELOPMENTONLY, "Can players call votes in Mann-Vs-Machine to enable or disable per-class limits?" );
+ConVar sv_vote_issue_classlimits_max( "sv_vote_issue_classlimits_max", "4", FCVAR_DEVELOPMENTONLY, "Maximum number of players (per-team) that can be any one class.", true, 1.f, false, 16.f );
+ConVar sv_vote_issue_classlimits_max_mvm( "sv_vote_issue_classlimits_max_mvm", "2", FCVAR_DEVELOPMENTONLY, "Maximum number of players (per-team) that can be any one class.", true, 1.f, false, 16.f );
+ConVar sv_vote_issue_classlimits_cooldown( "sv_vote_issue_classlimits_cooldown", "300", FCVAR_DEVELOPMENTONLY, "Minimum time before another classlimits vote can occur (in seconds)." );
 
 //-----------------------------------------------------------------------------
 // Purpose: 

--- a/src/game/server/vote_controller.cpp
+++ b/src/game/server/vote_controller.cpp
@@ -49,7 +49,8 @@ ConVar sv_vote_command_delay( "sv_vote_command_delay", "2", FCVAR_DEVELOPMENTONL
 ConVar sv_allow_votes( "sv_allow_votes", "1", FCVAR_NONE, "Allow voting?" );
 ConVar sv_vote_failure_timer( "sv_vote_failure_timer", "300", FCVAR_NONE, "A vote that fails cannot be re-submitted for this long" );
 #ifdef TF_DLL
-ConVar sv_vote_failure_timer_mvm( "sv_vote_failure_timer_mvm", "120", FCVAR_NONE, "A vote that fails in MvM cannot be re-submitted for this long" );
+//MvM - Not relevant to PF, made dev only
+ConVar sv_vote_failure_timer_mvm( "sv_vote_failure_timer_mvm", "120", FCVAR_NONE | FCVAR_DEVELOPMENTONLY, "A vote that fails in MvM cannot be re-submitted for this long" );
 #endif // TF_DLL
 ConVar sv_vote_creation_timer( "sv_vote_creation_timer", "150", FCVAR_NONE, "How long before a player can attempt to call another vote (in seconds)." );
 ConVar sv_vote_quorum_ratio( "sv_vote_quorum_ratio", "0.6", FCVAR_NOTIFY, "The minimum ratio of eligible players needed to pass a vote.  Min 0.1, Max 1.0.", true, 0.1f, true, 1.0f );

--- a/src/game/shared/teamplayroundbased_gamerules.cpp
+++ b/src/game/shared/teamplayroundbased_gamerules.cpp
@@ -203,7 +203,8 @@ ConVar mp_tournament( "mp_tournament", "0", FCVAR_REPLICATED | FCVAR_NOTIFY );
 ConVar mp_tournament_post_match_period( "mp_tournament_post_match_period", "90", FCVAR_REPLICATED, "The amount of time (in seconds) before the server resets post-match.", true, 5, true, 300 );
 
 #if defined( TF_CLIENT_DLL ) || defined( TF_DLL )
-ConVar mp_highlander( "mp_highlander", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Allow only 1 of each player class type." );
+//Highlander is not relevant to PF. Dev-only for the time being, we should probably nuke it eventually
+ConVar mp_highlander( "mp_highlander", "0", FCVAR_REPLICATED | FCVAR_NOTIFY | FCVAR_DEVELOPMENTONLY, "Allow only 1 of each player class type." );
 #endif
 #ifdef TF_DLL
 extern ConVar tf_competitive_preround_duration;

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -794,19 +794,16 @@ ConVar mp_tournament_prevent_team_switch_on_readyup( "mp_tournament_prevent_team
 ConVar mp_windifference( "mp_windifference", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Score difference between teams before server changes maps", true, 0, false, 0 );
 ConVar mp_windifference_min( "mp_windifference_min", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Minimum score needed for mp_windifference to be applied", true, 0, false, 0 );
 
-ConVar tf_tournament_classlimit_scout( "tf_tournament_classlimit_scout", "0", FCVAR_REPLICATED, "Tournament mode per-team class limit for Scouts.\n" );
-ConVar tf_tournament_classlimit_sniper( "tf_tournament_classlimit_sniper", "0", FCVAR_REPLICATED, "Tournament mode per-team class limit for Snipers.\n" );
-ConVar tf_tournament_classlimit_soldier( "tf_tournament_classlimit_soldier", "3", FCVAR_REPLICATED, "Tournament mode per-team class limit for Soldiers.\n" );
-ConVar tf_tournament_classlimit_demoman( "tf_tournament_classlimit_demoman", "1", FCVAR_REPLICATED, "Tournament mode per-team class limit for Demomenz.\n" );
-ConVar tf_tournament_classlimit_medic( "tf_tournament_classlimit_medic", "1", FCVAR_REPLICATED, "Tournament mode per-team class limit for Medics.\n" );
-ConVar tf_tournament_classlimit_heavy( "tf_tournament_classlimit_heavy", "0", FCVAR_REPLICATED, "Tournament mode per-team class limit for Heavies.\n" );
-ConVar tf_tournament_classlimit_pyro( "tf_tournament_classlimit_pyro", "0", FCVAR_REPLICATED, "Tournament mode per-team class limit for Pyros.\n" );
-ConVar tf_tournament_classlimit_spy( "tf_tournament_classlimit_spy", "0", FCVAR_REPLICATED, "Tournament mode per-team class limit for Spies.\n" );
-ConVar tf_tournament_classlimit_engineer( "tf_tournament_classlimit_engineer", "0", FCVAR_REPLICATED, "Tournament mode per-team class limit for Engineers.\n" );
+ConVar pf_classlimit_soldier( "pf_classlimit_soldier", "3", FCVAR_REPLICATED, "Per-team class limit for Soldiers.\n" );
+ConVar pf_classlimit_demoman( "pf_classlimit_demoman", "1", FCVAR_REPLICATED, "Per-team class limit for Demomen.\n" );
+ConVar pf_classlimit_medic( "pf_classlimit_medic", "1", FCVAR_REPLICATED, "Per-team class limit for Medics.\n" );
+
 ConVar tf_tournament_classchange_allowed( "tf_tournament_classchange_allowed", "1", FCVAR_REPLICATED, "Allow players to change class while the game is active?.\n" );
 ConVar tf_tournament_classchange_ready_allowed( "tf_tournament_classchange_ready_allowed", "1", FCVAR_REPLICATED, "Allow players to change class after they are READY?.\n" );
 
-ConVar tf_classlimit( "tf_classlimit", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Limit on how many players can be any class (i.e. tf_class_limit 2 would limit 2 players per class).\n", true, 0.f, false, 0.f );
+//Legacy TF command, making it dev only in favor of using pf_classlimit_*
+ConVar tf_classlimit( "tf_classlimit", "0", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED | FCVAR_NOTIFY, "Limit on how many players can be any class (i.e. tf_class_limit 2 would limit 2 players per class).\n", true, 0.f, false, 0.f );
+
 ConVar tf_player_movement_restart_freeze( "tf_player_movement_restart_freeze", "1", FCVAR_REPLICATED, "When set, prevent player movement during round restart" );
 
 ConVar tf_autobalance_ask_candidates_maxtime( "tf_autobalance_ask_candidates_maxtime", "10", FCVAR_REPLICATED );
@@ -14749,35 +14746,25 @@ void CTFGameRules::GetTeamGlowColor( int nTeam, float &r, float &g, float &b )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
+
+//PF - This is where we have removed access to the other classes.
+//The game treats their classlimits as 0 even outside of Tournament mode.
 int CTFGameRules::GetClassLimit( int iClass )
 {
-	if ( IsInTournamentMode() || IsPasstimeMode() )
+	switch ( iClass )
 	{
-		switch ( iClass )
-		{
-		case TF_CLASS_SCOUT: return tf_tournament_classlimit_scout.GetInt(); break;
-		case TF_CLASS_SNIPER: return tf_tournament_classlimit_sniper.GetInt(); break;
-		case TF_CLASS_SOLDIER: return tf_tournament_classlimit_soldier.GetInt(); break;
-		case TF_CLASS_DEMOMAN: return tf_tournament_classlimit_demoman.GetInt(); break;
-		case TF_CLASS_MEDIC: return tf_tournament_classlimit_medic.GetInt(); break;
-		case TF_CLASS_HEAVYWEAPONS: return tf_tournament_classlimit_heavy.GetInt(); break;
-		case TF_CLASS_PYRO: return tf_tournament_classlimit_pyro.GetInt(); break;
-		case TF_CLASS_SPY: return tf_tournament_classlimit_spy.GetInt(); break;
-		case TF_CLASS_ENGINEER: return tf_tournament_classlimit_engineer.GetInt(); break;
-		default:
-			break;
-		}
+	case TF_CLASS_SCOUT: return 0; break;
+	case TF_CLASS_SNIPER: return 0; break;
+	case TF_CLASS_SOLDIER: return pf_classlimit_soldier.GetInt(); break;
+	case TF_CLASS_DEMOMAN: return pf_classlimit_demoman.GetInt(); break;
+	case TF_CLASS_MEDIC: return pf_classlimit_medic.GetInt(); break;
+	case TF_CLASS_HEAVYWEAPONS: return 0; break;
+	case TF_CLASS_PYRO: return 0; break;
+	case TF_CLASS_SPY: return 0; break;
+	case TF_CLASS_ENGINEER: return 0; break;
+	default:
+		break;
 	}
-	else if ( IsInHighlanderMode() )
-	{
-		return 1;
-	}
-	else if ( tf_classlimit.GetInt() )
-	{
-		return tf_classlimit.GetInt();
-	}
-
-	return NO_CLASS_LIMIT;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_shareddefs.cpp
+++ b/src/game/shared/tf/tf_shareddefs.cpp
@@ -215,15 +215,15 @@ int GetClassIndexFromString( const char *pClassName, int nLastClassIndex/*=TF_LA
 int iRemapIndexToClass[TF_CLASS_MENU_BUTTONS] =
 {
 	0,
-		TF_CLASS_SCOUT,
 		TF_CLASS_SOLDIER,
-		TF_CLASS_PYRO,
 		TF_CLASS_DEMOMAN,
-		TF_CLASS_HEAVYWEAPONS,
-		TF_CLASS_ENGINEER,
 		TF_CLASS_MEDIC,
-		TF_CLASS_SNIPER,
-		TF_CLASS_SPY,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
 		0,
 		0,
 		TF_CLASS_RANDOM


### PR DESCRIPTION
In the current build, players can choose non-PF classes when outside of tournament mode and pass time

This PR fixes this with the following changes:

- Removed tournament and pass time checks from the classlimit commands
- Renamed the classlimit commands to pf_classlimit_*classname*, there are now only three commands.
- All non-PF classes are given a hard-coded classlimit of 0, effectively disabling them from play
- Other classlimit commands (mp_highlander, tf_classlimit, etc.) have been made developer-only since their functionality was partially removed (yet not completely nuked) in this change
- Changed the class index order, removing the non-PF classes from it
    - The 3 PF classes are now bound to the 1 2 3 buttons in the class select menu, also changing the class selection menu to reflect this change
    - This also affected the loadout subpanel screen through shared code, but this screen will be reworked or removed anyway
    - This may have other adverse effects that I had not noticed yet, but nothing obvious so far
- Made the tf_classlimit vote commands dev-only
- Disabled the extend map vote by default
- Enabled the change map vote by default
- Made sv_vote_failure_timer_mvm dev-only