### PR TITLE
Raise default teammate spawn glow time from 10 seconds to 31.7 years

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -11008,8 +11008,8 @@ void GlowColor_Callback( IConVar *var, const char *pOldValue, float flOldValue )
 }
 
 	ConVar pf_glow_healthcolor(
-	"pf_glow_healthcolor", "1", FCVAR_ARCHIVE,
-	"Enables health-based coloring of the teammate glow.", GlowColor_Callback );
+	"pf_glow_healthcolor", "0", FCVAR_ARCHIVE,
+	"Enables health-based coloring of the teammate glow. Might make team recognition difficult.", GlowColor_Callback );
 	//-----------------------------------------------------------------------------
 	// Purpose:
 	//-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -729,7 +729,12 @@ ConVar tf_mm_next_map_vote_time( "tf_mm_next_map_vote_time", "15", FCVAR_REPLICA
 static float g_fEternaweenAutodisableTime = 0.0f;
 
 ConVar tf_spec_xray( "tf_spec_xray", "1", FCVAR_NOTIFY | FCVAR_REPLICATED, "Allows spectators to see player glows. 1 = same team, 2 = both teams" );
-ConVar tf_spawn_glows_duration( "tf_spawn_glows_duration", "10", FCVAR_NOTIFY | FCVAR_REPLICATED, "How long should teammates glow after respawning\n" );
+// PF - Lazy hack
+ConVar tf_spawn_glows_duration(
+"tf_spawn_glows_duration", "999999999", FCVAR_NOTIFY | FCVAR_REPLICATED,
+"How long should teammates glow after respawning. In PASS Fortress, this is "
+"used for the teammate outlines. Rather than do something smart, we just used "
+"a big number. Good luck staying alive for 31.7 years.\n" );
 
 #ifdef GAME_DLL
 void cc_tf_forced_holiday_changed( IConVar *pConVar, const char *pOldString, float flOldValue )


### PR DESCRIPTION
Lazy fix but I couldn't find the relevant code for the time being. It's the same as what the tf2 devs did with stickybomb explosion timers to be fair

Also disables health colored glows by default for various reasons (team recognition issues, ugliness, this feels like something for players to mess around with rather than a good default)